### PR TITLE
경북대  FE 김건호 - 1단계 선물하기 메인 API 구현하기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@hookform/resolvers": "^5.1.1",
+        "axios": "^1.10.0",
         "emotion-reset": "^3.0.1",
         "lucide-react": "^0.523.0",
         "react": "^19.1.0",
@@ -3084,6 +3085,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/axe-core": {
       "version": "4.10.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
@@ -3092,6 +3099,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -3193,6 +3211,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -3321,6 +3352,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3438,6 +3481,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3475,6 +3527,20 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -3529,12 +3595,57 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -4030,6 +4141,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4045,6 +4176,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -4079,6 +4226,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -4154,6 +4338,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4176,6 +4372,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -4667,6 +4890,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4689,6 +4921,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/min-indent": {
@@ -5151,6 +5404,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@hookform/resolvers": "^5.1.1",
+    "axios": "^1.10.0",
     "emotion-reset": "^3.0.1",
     "lucide-react": "^0.523.0",
     "react": "^19.1.0",

--- a/src/api/ErrorHandler.ts
+++ b/src/api/ErrorHandler.ts
@@ -1,0 +1,44 @@
+import axios from "axios";
+import type { ApiError } from "@/api/types";
+
+class ApiErrorHandler {
+  static handleError(
+    error: unknown,
+    fallbackMessage = "알 수 없는 오류가 발생했습니다",
+  ): never {
+    if (axios.isAxiosError(error)) {
+      if (error.response) {
+        const errorData = error.response.data as BaseResponse<ApiError>;
+        const apiError = errorData.data;
+
+        const message = apiError?.message || fallbackMessage;
+        throw new Error(message);
+      } else if (error.request) {
+        throw new Error(
+          "네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.",
+        );
+      } else {
+        throw new Error("요청 설정 중 오류가 발생했습니다.");
+      }
+    }
+
+    if (error instanceof Error) {
+      throw new Error(error.message);
+    }
+
+    throw new Error(fallbackMessage);
+  }
+
+  static async executeApi<T>(
+    apiCall: () => Promise<T>,
+    fallbackMessage?: string,
+  ): Promise<T> {
+    try {
+      return await apiCall();
+    } catch (error) {
+      this.handleError(error, fallbackMessage);
+    }
+  }
+}
+
+export default ApiErrorHandler;

--- a/src/api/ErrorHandler.ts
+++ b/src/api/ErrorHandler.ts
@@ -1,44 +1,41 @@
 import axios from "axios";
 import type { ApiError } from "@/api/types";
 
-class ApiErrorHandler {
-  static handleError(
-    error: unknown,
-    fallbackMessage = "알 수 없는 오류가 발생했습니다",
-  ): never {
-    if (axios.isAxiosError(error)) {
-      if (error.response) {
-        const errorData = error.response.data as BaseResponse<ApiError>;
-        const apiError = errorData.data;
+export const handleApiError = (
+  error: unknown,
+  fallbackMessage = "알 수 없는 오류가 발생했습니다",
+): never => {
+  if (axios.isAxiosError(error)) {
+    if (error.response) {
+      const errorData = error.response.data as BaseResponse<ApiError>;
+      const apiError = errorData.data;
 
-        const message = apiError?.message || fallbackMessage;
-        throw new Error(message);
-      } else if (error.request) {
-        throw new Error(
-          "네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.",
-        );
-      } else {
-        throw new Error("요청 설정 중 오류가 발생했습니다.");
-      }
-    }
-
-    if (error instanceof Error) {
-      throw new Error(error.message);
-    }
-
-    throw new Error(fallbackMessage);
-  }
-
-  static async executeApi<T>(
-    apiCall: () => Promise<T>,
-    fallbackMessage?: string,
-  ): Promise<T> {
-    try {
-      return await apiCall();
-    } catch (error) {
-      this.handleError(error, fallbackMessage);
+      const message = apiError?.message || fallbackMessage;
+      throw new Error(message);
+    } else if (error.request) {
+      throw new Error(
+        "네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.",
+      );
+    } else {
+      throw new Error("요청 설정 중 오류가 발생했습니다.");
     }
   }
-}
 
-export default ApiErrorHandler;
+  if (error instanceof Error) {
+    throw new Error(error.message);
+  }
+
+  throw new Error(fallbackMessage);
+};
+
+export const executeApi = async <T>(
+  apiCall: () => Promise<T>,
+  fallbackMessage?: string,
+): Promise<T> => {
+  try {
+    return await apiCall();
+  } catch (error) {
+    handleApiError(error, fallbackMessage);
+    throw new Error("");
+  }
+};

--- a/src/api/ErrorHandler.ts
+++ b/src/api/ErrorHandler.ts
@@ -1,23 +1,22 @@
 import axios from "axios";
 import type { ApiError } from "@/api/types";
+import { API_ERROR_MESSAGE } from "@/constants";
 
 export const handleApiError = (
   error: unknown,
-  fallbackMessage = "알 수 없는 오류가 발생했습니다",
+  fallbackMessage = API_ERROR_MESSAGE.DEFAULT as string,
 ): never => {
-  if (axios.isAxiosError(error)) {
+  if (axios.isAxiosError<BaseResponse<ApiError>>(error)) {
     if (error.response) {
-      const errorData = error.response.data as BaseResponse<ApiError>;
+      const errorData = error.response.data;
       const apiError = errorData.data;
 
       const message = apiError?.message || fallbackMessage;
       throw new Error(message);
     } else if (error.request) {
-      throw new Error(
-        "네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.",
-      );
+      throw new Error(API_ERROR_MESSAGE.NETWORK);
     } else {
-      throw new Error("요청 설정 중 오류가 발생했습니다.");
+      throw new Error(API_ERROR_MESSAGE.SETTING);
     }
   }
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
+
+export const api = axios.create({
+  baseURL: API_BASE_URL,
+  timeout: 10000,
+});

--- a/src/api/login/signin.ts
+++ b/src/api/login/signin.ts
@@ -1,5 +1,6 @@
 import { api } from "@/api/api";
 import { executeApi } from "@/api/ErrorHandler";
+import { API_ERROR_MESSAGE } from "@/constants";
 
 interface SignInRequestBody {
   email: string;
@@ -21,5 +22,5 @@ export const signin = async (
       requestBody,
     );
     return response.data;
-  }, "로그인 중 오류가 발생했습니다.");
+  }, API_ERROR_MESSAGE.LOGIN);
 };

--- a/src/api/login/signin.ts
+++ b/src/api/login/signin.ts
@@ -1,0 +1,25 @@
+import { api } from "@/api/api";
+import ApiErrorHandler from "@/api/ErrorHandler";
+
+interface SignInRequestBody {
+  email: string;
+  password: string;
+}
+
+interface SignInResponseBody {
+  email: string;
+  name: string;
+  authToken: string;
+}
+
+export const signin = async (
+  requestBody: SignInRequestBody,
+): Promise<SignInResponseBody> => {
+  return ApiErrorHandler.executeApi(async () => {
+    const { data: response } = await api.post<BaseResponse<SignInResponseBody>>(
+      "/login",
+      requestBody,
+    );
+    return response.data;
+  }, "로그인 중 오류가 발생했습니다.");
+};

--- a/src/api/login/signin.ts
+++ b/src/api/login/signin.ts
@@ -1,5 +1,5 @@
 import { api } from "@/api/api";
-import ApiErrorHandler from "@/api/ErrorHandler";
+import { executeApi } from "@/api/ErrorHandler";
 
 interface SignInRequestBody {
   email: string;
@@ -15,7 +15,7 @@ interface SignInResponseBody {
 export const signin = async (
   requestBody: SignInRequestBody,
 ): Promise<SignInResponseBody> => {
-  return ApiErrorHandler.executeApi(async () => {
+  return executeApi(async () => {
     const { data: response } = await api.post<BaseResponse<SignInResponseBody>>(
       "/login",
       requestBody,

--- a/src/api/product/get-ranking-products.ts
+++ b/src/api/product/get-ranking-products.ts
@@ -1,0 +1,25 @@
+import { api } from "@/api/api";
+import ApiErrorHandler from "@/api/ErrorHandler";
+import type { ProductType } from "@/types";
+
+interface GetRankingProductParams {
+  targetType?: "ALL" | "FEMALE" | "MALE" | "TEEN";
+  rankType?: "MANY_WISH" | "MANY_RECEIVE" | "MANY_WISH_RECEIVE";
+}
+
+export const getRankingProduct = async (
+  params: GetRankingProductParams = {},
+): Promise<ProductType[]> => {
+  return ApiErrorHandler.executeApi(async () => {
+    const { data: response } = await api.get<BaseResponse<ProductType[]>>(
+      "/products/ranking",
+      {
+        params: {
+          targetType: params.targetType || "ALL",
+          rankType: params.rankType || "MANY_WISH",
+        },
+      },
+    );
+    return response.data;
+  }, "실시간 급상승 랭킹을 불러오는 중 오류가 발생했습니다.");
+};

--- a/src/api/product/get-ranking-products.ts
+++ b/src/api/product/get-ranking-products.ts
@@ -1,5 +1,5 @@
 import { api } from "@/api/api";
-import ApiErrorHandler from "@/api/ErrorHandler";
+import { executeApi } from "@/api/ErrorHandler";
 import type { TAB_DATA, TAGS } from "@/constants";
 import type { ProductType } from "@/types";
 
@@ -16,7 +16,7 @@ export const getRankingProduct = async (
     rankType: "MANY_WISH",
   },
 ): Promise<ProductType[]> => {
-  return ApiErrorHandler.executeApi(async () => {
+  return executeApi(async () => {
     const { data: response } = await api.get<BaseResponse<ProductType[]>>(
       "/products/ranking",
       {

--- a/src/api/product/get-ranking-products.ts
+++ b/src/api/product/get-ranking-products.ts
@@ -1,6 +1,6 @@
 import { api } from "@/api/api";
 import { executeApi } from "@/api/ErrorHandler";
-import type { TAB_DATA, TAGS } from "@/constants";
+import { API_ERROR_MESSAGE, type TAB_DATA, type TAGS } from "@/constants";
 import type { ProductType } from "@/types";
 
 export type RankingTargetType = (typeof TAGS)[number]["id"];
@@ -21,11 +21,11 @@ export const getRankingProduct = async (
       "/products/ranking",
       {
         params: {
-          targetType: params.targetType || "ALL",
-          rankType: params.rankType || "MANY_WISH",
+          targetType: params.targetType,
+          rankType: params.rankType,
         },
       },
     );
     return response.data;
-  }, "실시간 급상승 랭킹을 불러오는 중 오류가 발생했습니다.");
+  }, API_ERROR_MESSAGE.RANKING);
 };

--- a/src/api/product/get-ranking-products.ts
+++ b/src/api/product/get-ranking-products.ts
@@ -1,14 +1,20 @@
 import { api } from "@/api/api";
 import ApiErrorHandler from "@/api/ErrorHandler";
+import type { TAB_DATA, TAGS } from "@/constants";
 import type { ProductType } from "@/types";
 
+export type RankingTargetType = (typeof TAGS)[number]["id"];
+export type RankingRankType = (typeof TAB_DATA)[number]["id"];
 interface GetRankingProductParams {
-  targetType?: "ALL" | "FEMALE" | "MALE" | "TEEN";
-  rankType?: "MANY_WISH" | "MANY_RECEIVE" | "MANY_WISH_RECEIVE";
+  targetType: RankingTargetType;
+  rankType: RankingRankType;
 }
 
 export const getRankingProduct = async (
-  params: GetRankingProductParams = {},
+  params: GetRankingProductParams = {
+    targetType: "ALL",
+    rankType: "MANY_WISH",
+  },
 ): Promise<ProductType[]> => {
   return ApiErrorHandler.executeApi(async () => {
     const { data: response } = await api.get<BaseResponse<ProductType[]>>(

--- a/src/api/product/index.ts
+++ b/src/api/product/index.ts
@@ -1,0 +1,1 @@
+export { getRankingProduct } from "@/api/product/get-ranking-products";

--- a/src/api/themes/get-themes.ts
+++ b/src/api/themes/get-themes.ts
@@ -1,7 +1,7 @@
 import { api } from "@/api/api";
 import ApiErrorHandler from "@/api/ErrorHandler";
 
-interface GetThemesResponseBody {
+export interface GetThemesResponseBody {
   themeId: number;
   name: string;
   image: string;

--- a/src/api/themes/get-themes.ts
+++ b/src/api/themes/get-themes.ts
@@ -1,5 +1,6 @@
 import { api } from "@/api/api";
 import { executeApi } from "@/api/ErrorHandler";
+import { API_ERROR_MESSAGE } from "@/constants";
 
 export interface GetThemesResponseBody {
   themeId: number;
@@ -11,5 +12,5 @@ export const getThemes = async (): Promise<GetThemesResponseBody[]> => {
     const { data: response } =
       await api.get<BaseResponse<GetThemesResponseBody[]>>("/themes");
     return response.data;
-  }, "테마를 불러오는 중 오류가 발생했습니다.");
+  }, API_ERROR_MESSAGE.THEMES);
 };

--- a/src/api/themes/get-themes.ts
+++ b/src/api/themes/get-themes.ts
@@ -1,0 +1,15 @@
+import { api } from "@/api/api";
+import ApiErrorHandler from "@/api/ErrorHandler";
+
+interface GetThemesResponseBody {
+  themeId: number;
+  name: string;
+  image: string;
+}
+export const getThemes = async (): Promise<GetThemesResponseBody[]> => {
+  return ApiErrorHandler.executeApi(async () => {
+    const { data: response } =
+      await api.get<BaseResponse<GetThemesResponseBody[]>>("/themes");
+    return response.data;
+  }, "테마를 불러오는 중 오류가 발생했습니다.");
+};

--- a/src/api/themes/get-themes.ts
+++ b/src/api/themes/get-themes.ts
@@ -1,5 +1,5 @@
 import { api } from "@/api/api";
-import ApiErrorHandler from "@/api/ErrorHandler";
+import { executeApi } from "@/api/ErrorHandler";
 
 export interface GetThemesResponseBody {
   themeId: number;
@@ -7,7 +7,7 @@ export interface GetThemesResponseBody {
   image: string;
 }
 export const getThemes = async (): Promise<GetThemesResponseBody[]> => {
-  return ApiErrorHandler.executeApi(async () => {
+  return executeApi(async () => {
     const { data: response } =
       await api.get<BaseResponse<GetThemesResponseBody[]>>("/themes");
     return response.data;

--- a/src/api/themes/index.ts
+++ b/src/api/themes/index.ts
@@ -1,0 +1,1 @@
+export { getThemes } from "@/api/themes/get-themes";

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,5 @@
+export interface ApiError {
+  status: string;
+  statusCode: number;
+  message: string;
+}

--- a/src/augmentations/api.d.ts
+++ b/src/augmentations/api.d.ts
@@ -1,0 +1,3 @@
+declare type BaseResponse<T> = {
+  data: T;
+};

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -1,0 +1,35 @@
+import { keyframes } from "@emotion/react";
+import styled from "@emotion/styled";
+
+const spin = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+const SpinnerContainer = styled.div({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  height: "100%",
+  width: "100%",
+});
+
+const Spinner = styled.div({
+  border: "4px solid rgba(0, 0, 0, 0.1)",
+  borderTop: "4px solid #3498db",
+  borderRadius: "50%",
+  width: "40px",
+  height: "40px",
+  animation: `${spin} 1s linear infinite`,
+});
+
+export const LoadingSpinner = () => {
+  return (
+    <SpinnerContainer>
+      <Spinner />
+    </SpinnerContainer>
+  );
+};

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -1,3 +1,4 @@
 export { Input } from "@/components/common/Input";
 export { Button } from "@/components/common/Button";
 export { ErrorMessage } from "@/components/common/ErrorMessage";
+export { LoadingSpinner } from "@/components/common/LoadingSpinner";

--- a/src/components/common/stories/LoadingSpinner.stories.tsx
+++ b/src/components/common/stories/LoadingSpinner.stories.tsx
@@ -1,0 +1,13 @@
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof LoadingSpinner> = {
+  component: LoadingSpinner,
+};
+
+export default meta;
+type Story = StoryObj<typeof LoadingSpinner>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/main/HotGiftRanking.tsx
+++ b/src/components/main/HotGiftRanking.tsx
@@ -7,7 +7,8 @@ import {
   HotGiftRankingTab,
   HotGiftRankingTag,
 } from "@/components/main";
-import { TAGS } from "@/constants";
+import { TAB_DATA, TAGS } from "@/constants";
+import { parseUrlParam } from "@/utils";
 import styled from "@emotion/styled";
 import { useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -39,10 +40,16 @@ const HotGiftRankingSectionTagContainer = styled.div(({ theme }) => ({
 export const HotGiftRanking = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const selectedTag: RankingTargetType = (searchParams.get("targetType") ||
-    "ALL") as RankingTargetType;
-  const selectedTab: RankingRankType = (searchParams.get("rankType") ||
-    "MANY_WISH") as RankingRankType;
+  const selectedTag = parseUrlParam(
+    searchParams.get("targetType"),
+    TAGS,
+    "ALL",
+  );
+  const selectedTab = parseUrlParam(
+    searchParams.get("rankType"),
+    TAB_DATA,
+    "MANY_WISH",
+  );
 
   const handleParamChange = useCallback(
     (

--- a/src/components/main/HotGiftRanking.tsx
+++ b/src/components/main/HotGiftRanking.tsx
@@ -1,8 +1,13 @@
+import type {
+  RankingRankType,
+  RankingTargetType,
+} from "@/api/product/get-ranking-products";
 import {
   HotGiftRankingGrid,
   HotGiftRankingTab,
   HotGiftRankingTag,
 } from "@/components/main";
+import { TAGS } from "@/constants";
 import styled from "@emotion/styled";
 import { useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -31,21 +36,19 @@ const HotGiftRankingSectionTagContainer = styled.div(({ theme }) => ({
   marginBottom: `${theme.spacing4}`,
 }));
 
-const tags = [
-  { id: "ALL", emoji: "ALL", text: "전체" },
-  { id: "FEMALE", emoji: "👩", text: "여성이" },
-  { id: "MALE", emoji: "👨", text: "남성이" },
-  { id: "TEEN", emoji: "👦", text: "청소년이" },
-];
-
 export const HotGiftRanking = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const selectedTag = searchParams.get("targetType") || "ALL";
-  const selectedTab = searchParams.get("rankType") || "MANY_WISH";
+  const selectedTag: RankingTargetType = (searchParams.get("targetType") ||
+    "ALL") as RankingTargetType;
+  const selectedTab: RankingRankType = (searchParams.get("rankType") ||
+    "MANY_WISH") as RankingRankType;
 
   const handleParamChange = useCallback(
-    (key: "targetType" | "rankType", value: string) => {
+    (
+      key: "targetType" | "rankType",
+      value: RankingTargetType | RankingRankType,
+    ) => {
       const newParams = new URLSearchParams(searchParams);
       newParams.set(key, value);
       setSearchParams(newParams);
@@ -59,7 +62,7 @@ export const HotGiftRanking = () => {
         실시간 급상승 선물랭킹
       </HotGiftRankingSectionTitle>
       <HotGiftRankingSectionTagContainer>
-        {tags.map(tag => (
+        {TAGS.map(tag => (
           <HotGiftRankingTag
             key={tag.id}
             isSelected={selectedTag === tag.id}

--- a/src/components/main/HotGiftRankingGrid.tsx
+++ b/src/components/main/HotGiftRankingGrid.tsx
@@ -1,8 +1,8 @@
-import { generateMockArray } from "@/__mock__/generate-mock-array";
-import { Button } from "@/components/common";
+import { Button, LoadingSpinner } from "@/components/common";
 import { useRouter } from "@/hooks/common/useRouter";
+import { useRankingProducts } from "@/hooks/products/useRankingProducts";
 import styled from "@emotion/styled";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const HotGiftRankingGridContainer = styled.div(({ theme }) => ({
   display: "grid",
@@ -69,17 +69,43 @@ const ButtonContainer = styled.div(({ theme }) => ({
   padding: `${theme.spacing8} 0 ${theme.spacing10} 0`,
 }));
 
+const EmptyContainer = styled.div(({ theme }) => ({
+  gridColumn: "1 / -1",
+  height: "50vh",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: `${theme.spacing8} 0`,
+  color: `${theme.color.gray[900]}`,
+  fontSize: `${theme.typography.body1Regular.fontSize}`,
+}));
+
 const RANK_CORRECTION_NUMBER = 1;
+const INITIAL_SHOW_COUNT = 6;
 
 export const HotGiftRankingGrid = () => {
   const [showMore, setShowMore] = useState(false);
+  const { products, loading, isEmpty } = useRankingProducts();
   const { goOrderPage } = useRouter();
-  const INITIAL_SHOW_COUNT = 6;
-  const mockData = generateMockArray();
-  const displayedItems = showMore
-    ? mockData
-    : mockData.slice(0, INITIAL_SHOW_COUNT);
 
+  useEffect(() => {
+    setShowMore(false);
+  }, [products]);
+
+  const displayedItems = showMore
+    ? products
+    : products.slice(0, INITIAL_SHOW_COUNT);
+
+  if (loading) {
+    return (
+      <EmptyContainer>
+        <LoadingSpinner />
+      </EmptyContainer>
+    );
+  }
+  if (isEmpty) {
+    return <EmptyContainer>상품이 없습니다.</EmptyContainer>;
+  }
   return (
     <>
       <HotGiftRankingGridContainer>
@@ -88,9 +114,7 @@ export const HotGiftRankingGrid = () => {
             key={item.id}
             onClick={() => goOrderPage(item.id)}
           >
-            <HotGiftRankingImageContainer
-              src={item.imageURL}
-            ></HotGiftRankingImageContainer>
+            <HotGiftRankingImageContainer src={item.imageURL} alt={item.name} />
             <RankBadge rank={index + RANK_CORRECTION_NUMBER}>
               {index + RANK_CORRECTION_NUMBER}
             </RankBadge>
@@ -101,7 +125,7 @@ export const HotGiftRankingGrid = () => {
         ))}
       </HotGiftRankingGridContainer>
 
-      {mockData.length > INITIAL_SHOW_COUNT && (
+      {products.length > INITIAL_SHOW_COUNT && (
         <ButtonContainer>
           <Button
             variant="secondary"

--- a/src/components/main/HotGiftRankingTab.tsx
+++ b/src/components/main/HotGiftRankingTab.tsx
@@ -1,3 +1,5 @@
+import type { RankingRankType } from "@/api/product/get-ranking-products";
+import { TAB_DATA } from "@/constants";
 import styled from "@emotion/styled";
 
 const HotGiftTabContainer = styled.div(({ theme }) => ({
@@ -36,15 +38,9 @@ const HotGiftTabTag = styled.button<{ isSelected: boolean }>(
 );
 
 interface HotGiftRankingTabProp {
-  selectedTab: string;
-  onTabChange: (tabId: string) => void;
+  selectedTab: RankingRankType;
+  onTabChange: (tabId: RankingRankType) => void;
 }
-
-const tabData = [
-  { id: "MANY_WISH", text: "받고 싶어한" },
-  { id: "MANY_RECEIVE", text: "많이 선물한" },
-  { id: "MANY_WISH_RECEIVE", text: "위시로 받은" },
-];
 
 export const HotGiftRankingTab = ({
   onTabChange,
@@ -52,7 +48,7 @@ export const HotGiftRankingTab = ({
 }: HotGiftRankingTabProp) => {
   return (
     <HotGiftTabContainer>
-      {tabData.map(tab => (
+      {TAB_DATA.map(tab => (
         <HotGiftTabTag
           key={tab.id}
           isSelected={selectedTab === tab.id}

--- a/src/components/main/PresentTheme.tsx
+++ b/src/components/main/PresentTheme.tsx
@@ -1,5 +1,6 @@
-import { category } from "@/__mock__";
+import { LoadingSpinner } from "@/components/common";
 import { ThemeItem } from "@/components/main";
+import { useGetThemeData } from "@/hooks/themes/useGetThemeData";
 import styled from "@emotion/styled";
 
 const PresentSectionPadding = styled.div(({ theme }) => ({
@@ -38,7 +39,25 @@ const PresentSectionGridContainer = styled.div(({ theme }) => ({
 }));
 
 export const PresentTheme = () => {
-  const categories = category;
+  const { themes, loading, error, isEmpty } = useGetThemeData();
+
+  const renderContent = () => {
+    if (loading) {
+      return <LoadingSpinner />;
+    }
+
+    if (error || isEmpty) {
+      return null;
+    }
+
+    return (
+      <PresentSectionGridContainer>
+        {themes.map(theme => (
+          <ThemeItem key={theme.themeId} {...theme} />
+        ))}
+      </PresentSectionGridContainer>
+    );
+  };
   return (
     <>
       <PresentSectionPadding />
@@ -46,11 +65,7 @@ export const PresentTheme = () => {
         <PresentSectionTitleWrapper>
           <PresentSectionTitle>선물 테마</PresentSectionTitle>
         </PresentSectionTitleWrapper>
-        <PresentSectionGridContainer>
-          {categories.map(category => (
-            <ThemeItem key={category.themeId} {...category} />
-          ))}
-        </PresentSectionGridContainer>
+        {renderContent()}
       </PresentSectionContainer>
       <PresentSectionPadding />
     </>

--- a/src/components/main/ThemeItem.tsx
+++ b/src/components/main/ThemeItem.tsx
@@ -14,6 +14,7 @@ const ThemeItemImage = styled.img({
   width: "50px",
   height: "50px",
   objectFit: "contain",
+  borderRadius: "18px",
 });
 
 const ThemeItemTitle = styled.p(({ theme }) => ({

--- a/src/constants/api-error-message.ts
+++ b/src/constants/api-error-message.ts
@@ -1,0 +1,8 @@
+export const API_ERROR_MESSAGE = {
+  DEFAULT: "알 수 없는 오류가 발생했습니다.",
+  NETWORK: "네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.",
+  SETTING: "요청 설정 중 오류가 발생했습니다.",
+  LOGIN: "로그인 중 오류가 발생했습니다.",
+  RANKING: "실시간 급상승 랭킹을 불러오는 중 오류가 발생했습니다.",
+  THEMES: "테마를 불러오는 중 오류가 발생했습니다.",
+} as const;

--- a/src/constants/email-storage-key.ts
+++ b/src/constants/email-storage-key.ts
@@ -1,1 +1,0 @@
-export const EMAIL_STORAGE_KEY = "kakaotech/userInfo";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -8,3 +8,5 @@ export {
 } from "@/constants/storage-key";
 export { ORDER_ERROR_MESSAGE } from "@/constants/order-error-messages";
 export { NON_BREAKING_SPACE } from "@/constants/non-breaking-code";
+export { TAB_DATA } from "@/constants/tabs";
+export { TAGS } from "@/constants/tags";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,10 @@
 export { ROUTE_PATH } from "@/constants/route-path";
 export { LOGIN_ERROR_MESSAGE } from "@/constants/login-error-messages";
 export { EMAIL_REGEX, PHONE_REGEX } from "@/constants/regex";
-export { EMAIL_STORAGE_KEY } from "@/constants/email-storage-key";
+export {
+  EMAIL_STORAGE_KEY,
+  AUTH_TOKEN_KEY,
+  USER_NAME_KEY,
+} from "@/constants/storage-key";
 export { ORDER_ERROR_MESSAGE } from "@/constants/order-error-messages";
 export { NON_BREAKING_SPACE } from "@/constants/non-breaking-code";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -10,3 +10,4 @@ export { ORDER_ERROR_MESSAGE } from "@/constants/order-error-messages";
 export { NON_BREAKING_SPACE } from "@/constants/non-breaking-code";
 export { TAB_DATA } from "@/constants/tabs";
 export { TAGS } from "@/constants/tags";
+export { API_ERROR_MESSAGE } from "@/constants/api-error-message";

--- a/src/constants/storage-key.ts
+++ b/src/constants/storage-key.ts
@@ -1,0 +1,3 @@
+export const EMAIL_STORAGE_KEY = "kakaotech/userInfo";
+export const AUTH_TOKEN_KEY = "authToken";
+export const USER_NAME_KEY = "userName";

--- a/src/constants/tabs.ts
+++ b/src/constants/tabs.ts
@@ -1,0 +1,5 @@
+export const TAB_DATA = [
+  { id: "MANY_WISH", text: "받고 싶어한" },
+  { id: "MANY_RECEIVE", text: "많이 선물한" },
+  { id: "MANY_WISH_RECEIVE", text: "위시로 받은" },
+] as const;

--- a/src/constants/tags.ts
+++ b/src/constants/tags.ts
@@ -1,0 +1,6 @@
+export const TAGS = [
+  { id: "ALL", emoji: "ALL", text: "전체" },
+  { id: "FEMALE", emoji: "👩", text: "여성이" },
+  { id: "MALE", emoji: "👨", text: "남성이" },
+  { id: "TEEN", emoji: "👦", text: "청소년이" },
+] as const;

--- a/src/contexts/order/index.ts
+++ b/src/contexts/order/index.ts
@@ -1,4 +1,3 @@
-export * from "@/contexts/order/order-validation";
 export * from "@/contexts/order/types";
 export {
   orderSchema,

--- a/src/hooks/common/useApiStatus.ts
+++ b/src/hooks/common/useApiStatus.ts
@@ -1,0 +1,32 @@
+import { API_ERROR_MESSAGE } from "@/constants";
+import { useCallback, useState } from "react";
+
+interface UseApiStatusResult<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  execute: (apiCall: () => Promise<T>) => Promise<void>;
+}
+
+export const useApiStatus = <T>(): UseApiStatusResult<T> => {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const execute = useCallback(async (apiCall: () => Promise<T>) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await apiCall();
+      setData(result);
+    } catch (error) {
+      setError(
+        error instanceof Error ? error.message : API_ERROR_MESSAGE.DEFAULT,
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { data, loading, error, execute };
+};

--- a/src/hooks/login/useLoginForm.ts
+++ b/src/hooks/login/useLoginForm.ts
@@ -4,10 +4,14 @@ import { useSearchParams } from "react-router-dom";
 import { setUserInfo } from "@/utils/storage";
 import { useRouter } from "@/hooks/common/useRouter";
 import { loginSchema, type LoginFormData } from "@/utils";
+import { useState } from "react";
+import { signin } from "@/api/login/signin";
 
 export const useLoginForm = () => {
   const { navigate, location } = useRouter();
   const [searchParams] = useSearchParams();
+  const [isLoading, setIsLoading] = useState(false);
+  const [loginError, setLoginError] = useState<string | null>(null);
 
   const {
     register,
@@ -34,11 +38,32 @@ export const useLoginForm = () => {
     }
   })();
 
-  const onSubmit = (values: LoginFormData) => {
-    setUserInfo({ email: values.id });
-    const previousPage = location.state?.from;
-    const redirectPath = previousPage || searchParams.get("redirect") || "/";
-    navigate(redirectPath);
+  const onSubmit = async (values: LoginFormData) => {
+    setIsLoading(true);
+    setLoginError(null);
+    try {
+      const response = await signin({
+        email: values.id,
+        password: values.password,
+      });
+      setUserInfo({
+        email: response.email,
+        authToken: response.authToken,
+        name: response.name,
+      });
+
+      const previousPage = location.state?.from;
+      const redirectPath = previousPage || searchParams.get("redirect") || "/";
+      navigate(redirectPath);
+    } catch (error) {
+      if (error instanceof Error) {
+        setLoginError(error.message);
+      } else {
+        setLoginError("로그인 중 오류가 발생했습니다. 다시 시도해주세요.");
+      }
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return {
@@ -46,5 +71,7 @@ export const useLoginForm = () => {
     handleSubmit: handleSubmit(onSubmit),
     errors,
     isFormValid: isFormValid,
+    isLoading,
+    loginError,
   };
 };

--- a/src/hooks/products/useRankingProducts.ts
+++ b/src/hooks/products/useRankingProducts.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import { getRankingProduct } from "@/api/product";
+import type { ProductType } from "@/types";
+
+export const useRankingProducts = () => {
+  const [products, setProducts] = useState<ProductType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchParams] = useSearchParams();
+
+  const selectedTag = searchParams.get("targetType") || "ALL";
+  const selectedTab = searchParams.get("rankType") || "MANY_WISH";
+
+  useEffect(() => {
+    const fetchRankingProducts = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const data = await getRankingProduct({
+          targetType: selectedTag as "ALL" | "FEMALE" | "MALE" | "TEEN",
+          rankType: selectedTab as
+            | "MANY_WISH"
+            | "MANY_RECEIVE"
+            | "MANY_WISH_RECEIVE",
+        });
+
+        setProducts(data);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "데이터를 불러오는 중 오류가 발생했습니다.",
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRankingProducts();
+  }, [selectedTag, selectedTab]);
+
+  return {
+    products,
+    loading,
+    error,
+    isEmpty: products.length === 0,
+  };
+};

--- a/src/hooks/products/useRankingProducts.ts
+++ b/src/hooks/products/useRankingProducts.ts
@@ -2,6 +2,10 @@ import { useState, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import { getRankingProduct } from "@/api/product";
 import type { ProductType } from "@/types";
+import type {
+  RankingRankType,
+  RankingTargetType,
+} from "@/api/product/get-ranking-products";
 
 export const useRankingProducts = () => {
   const [products, setProducts] = useState<ProductType[]>([]);
@@ -9,8 +13,10 @@ export const useRankingProducts = () => {
   const [error, setError] = useState<string | null>(null);
   const [searchParams] = useSearchParams();
 
-  const selectedTag = searchParams.get("targetType") || "ALL";
-  const selectedTab = searchParams.get("rankType") || "MANY_WISH";
+  const selectedTag: RankingTargetType = (searchParams.get("targetType") ||
+    "ALL") as RankingTargetType;
+  const selectedTab: RankingRankType = (searchParams.get("rankType") ||
+    "MANY_WISH") as RankingRankType;
 
   useEffect(() => {
     const fetchRankingProducts = async () => {
@@ -19,11 +25,8 @@ export const useRankingProducts = () => {
         setError(null);
 
         const data = await getRankingProduct({
-          targetType: selectedTag as "ALL" | "FEMALE" | "MALE" | "TEEN",
-          rankType: selectedTab as
-            | "MANY_WISH"
-            | "MANY_RECEIVE"
-            | "MANY_WISH_RECEIVE",
+          targetType: selectedTag as RankingTargetType,
+          rankType: selectedTab as RankingRankType,
         });
 
         setProducts(data);

--- a/src/hooks/products/useRankingProducts.ts
+++ b/src/hooks/products/useRankingProducts.ts
@@ -1,53 +1,42 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import { getRankingProduct } from "@/api/product";
 import type { ProductType } from "@/types";
-import type {
-  RankingRankType,
-  RankingTargetType,
-} from "@/api/product/get-ranking-products";
+import { TAB_DATA, TAGS } from "@/constants";
+import { parseUrlParam } from "@/utils";
+import { useApiStatus } from "@/hooks/common/useApiStatus";
 
 export const useRankingProducts = () => {
-  const [products, setProducts] = useState<ProductType[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [searchParams] = useSearchParams();
-
-  const selectedTag: RankingTargetType = (searchParams.get("targetType") ||
-    "ALL") as RankingTargetType;
-  const selectedTab: RankingRankType = (searchParams.get("rankType") ||
-    "MANY_WISH") as RankingRankType;
-
-  useEffect(() => {
-    const fetchRankingProducts = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-
-        const data = await getRankingProduct({
-          targetType: selectedTag as RankingTargetType,
-          rankType: selectedTab as RankingRankType,
-        });
-
-        setProducts(data);
-      } catch (err) {
-        setError(
-          err instanceof Error
-            ? err.message
-            : "데이터를 불러오는 중 오류가 발생했습니다.",
-        );
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchRankingProducts();
-  }, [selectedTag, selectedTab]);
-
-  return {
-    products,
+  const {
+    data: products,
     loading,
     error,
-    isEmpty: products.length === 0,
+    execute,
+  } = useApiStatus<ProductType[]>();
+  const selectedTag = parseUrlParam(
+    searchParams.get("targetType"),
+    TAGS,
+    "ALL",
+  );
+  const selectedTab = parseUrlParam(
+    searchParams.get("rankType"),
+    TAB_DATA,
+    "MANY_WISH",
+  );
+  useEffect(() => {
+    execute(() =>
+      getRankingProduct({
+        targetType: selectedTag,
+        rankType: selectedTab,
+      }),
+    );
+  }, [execute, selectedTab, selectedTag]);
+
+  return {
+    products: products || [],
+    loading,
+    error,
+    isEmpty: products?.length === 0,
   };
 };

--- a/src/hooks/themes/useGetThemeData.ts
+++ b/src/hooks/themes/useGetThemeData.ts
@@ -1,37 +1,23 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { getThemes } from "@/api/themes";
 import type { GetThemesResponseBody } from "@/api/themes/get-themes";
+import { useApiStatus } from "@/hooks/common/useApiStatus";
 
 export const useGetThemeData = () => {
-  const [themes, setThemes] = useState<GetThemesResponseBody[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
+  const {
+    data: themes,
+    error,
+    execute,
+    loading,
+  } = useApiStatus<GetThemesResponseBody[]>();
   useEffect(() => {
-    const fetchThemes = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const themeData = await getThemes();
-        setThemes(themeData);
-      } catch (err) {
-        setError(
-          err instanceof Error
-            ? err.message
-            : "알 수 없는 오류가 발생했습니다.",
-        );
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchThemes();
-  }, []);
+    execute(getThemes);
+  }, [execute]);
 
   return {
-    themes,
+    themes: themes || [],
     loading,
     error,
-    isEmpty: themes.length === 0,
+    isEmpty: themes?.length === 0,
   };
 };

--- a/src/hooks/themes/useGetThemeData.ts
+++ b/src/hooks/themes/useGetThemeData.ts
@@ -1,11 +1,6 @@
 import { useState, useEffect } from "react";
 import { getThemes } from "@/api/themes";
-
-interface GetThemesResponseBody {
-  themeId: number;
-  name: string;
-  image: string;
-}
+import type { GetThemesResponseBody } from "@/api/themes/get-themes";
 
 export const useGetThemeData = () => {
   const [themes, setThemes] = useState<GetThemesResponseBody[]>([]);

--- a/src/hooks/themes/useGetThemeData.ts
+++ b/src/hooks/themes/useGetThemeData.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect } from "react";
+import { getThemes } from "@/api/themes";
+
+interface GetThemesResponseBody {
+  themeId: number;
+  name: string;
+  image: string;
+}
+
+export const useGetThemeData = () => {
+  const [themes, setThemes] = useState<GetThemesResponseBody[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchThemes = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const themeData = await getThemes();
+        setThemes(themeData);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "알 수 없는 오류가 발생했습니다.",
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchThemes();
+  }, []);
+
+  return {
+    themes,
+    loading,
+    error,
+    isEmpty: themes.length === 0,
+  };
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "@/utils/storage";
 export * from "@/utils/login-validator";
 export * from "@/utils/login-schema";
+export * from "@/utils/url-guard";

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -4,6 +4,8 @@ type TypeGuard<T> = (value: unknown) => value is T;
 
 interface UserInfo {
   email: string;
+  authToken: string;
+  name: string;
 }
 
 export const setSessionStorageItem = <T>(key: string, value: T) => {

--- a/src/utils/url-guard.ts
+++ b/src/utils/url-guard.ts
@@ -1,0 +1,10 @@
+export const parseUrlParam = <T extends string>(
+  value: string | null,
+  validValues: readonly { id: T }[],
+  defaultValue: T,
+): T => {
+  if (value && validValues.some(item => item.id === value)) {
+    return value as T;
+  }
+  return defaultValue;
+};


### PR DESCRIPTION
안녕하세요 멘토님!
이번 PR에서는 1단계 선물하기 메인 API 구현하기를 진행했습니다!

---
## 2025-07-16 추가 내용
- 리뷰 내용을 반영하여 수정을 진행했습니다.
- `url-guard.ts`
  - 사용자가 url에 직접 rankType과 targetType을 변경했을 때, 타입에 정의되지 않은 값을 입력하면 기본 값인 "ALL"과 "MANY_WISH"로 설정하여 해당 상품들을 보여줍니다.
  - 타입에 정의된 값이라면 정상적으로 해당 상품들을 보여줍니다.
- `useApiStatus.ts`
  - api를 불러오는 곳에서 공통적으로 api에 대한 loading과 error처리, 데이터 페칭을 위한 커스텀 훅을 작성했습니다.
- `api-error-message.ts`
  - api 요청 후 에러 발생시 서버에서 반환하는 message가 아닌 기본 에러 메시지들을 상수로 정의했습니다.
- `rankType`,`targetType`에 대한 불필요한 타입 단언을 제거했습니다.

---

## 구현 내용
- 응답이 대부분 `{ data: ... }` 형태로 내려오고 있는 것을 확인하고 이 공통적인 구조를 효과적으로 타입 정의하고 재사용하기 위해 `BaseResponse<T>` 타입을 추가했습니다.
- axios를 사용하여 기본 api요청 함수를 구현했습니다.
- api 에러 커스텀 핸들러를 만들어 api함수 내에서 에러 처리를 간단하게 하려고 노력했습니다.
- 컴포넌트에서 최대한 데이터 페칭 로직을 숨기기 위해  커스텀 훅 형태로 만들어 사용했습니다.
- 로딩 시 사용할 공용 컴포넌트인 `LoadingSpinner.tsx`를 추가했습니다.
- 로그인 쪽의 경우 단계를 착각하여 만들다 멈췄습니다..ㅎ

---

## 궁금한 내용
- 에러 핸들링을 위해 별도로 파일 만들었는데, 멘토님(개인 혹은 팀에서)은 어떤 방식으로 구현하여 사용하는지 궁금합니다!
  - 에러 처리를 하는 방식이 너무 다양하고 에러의 중요도?를 구분하는 것이 항상 고민이었습니다.
  - 추가)클래스에서 함수형으로 바꾼 이유
    - Tree-shaking과 React에서는 함수형 방식이 어울릴 것 같아서 변경했습니다.
- 저의 경우 api함수를 구현한 파일에 requestBody나 responseBody를 interface로 만들어 두고 사용합니다(응집성을 위해).
  - 고민은 실제 api를 호출하여 데이터를 받아오는 파일에서 해당 타입을 api파일에서 import하는 방식과, types폴더(혹은 파일)에 두고 한 번에 관리하는 방식 중 어떤 것을 선호하시는지 궁금합니다!