### PR TITLE
[충남대 FE 이희성] 2단계 - 로그인, 주문하기 API 구현하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 #### 2. 주문하기 기능
 - [x] /products/:productId/summary api를 사용하여 제품 정보 가져오기
 - [x] 제품 정보 API에서 4XX 에러가 발생하면 Toast를 통해 에러메시지를 보여주고, 선물하기 홈으로 연결
-- [ ] 보내는 사람 Input Field에 userInfo의 name을 defaultValue로 채우기
+- [x] 보내는 사람 Input Field에 userInfo의 name을 defaultValue로 채우기
 - [ ] /order api를 사용하여 주문하기 기능을 완성
 - [ ] 주문하기 API의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken을 넣어야만 동작
 - [ ] 주문하기 API에서 401 에러가 발생하면 로그인 페이지로 연결

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 ### 요구사항
 
 #### 1. 로그인 기능
-- [ ] /login api 를 사용하여 로그인 기능을 완성
-- [ ] 로그인 성공 시 내려오는 authToken과 email, name을 userInfo storage에 저장하고 활용
-- [ ] 4XX 에러가 발생하면 Toast를 통해 에러메시지 출력
+- [x] /login api 를 사용하여 로그인 기능을 완성
+- [x] 로그인 성공 시 내려오는 authToken과 email, name을 userInfo storage에 저장하고 활용
+- [x] 4XX 에러가 발생하면 Toast를 통해 에러메시지 출력
 
 #### 2. 주문하기 기능
 - [ ] /products/:productId/summary api를 사용하여 제품 정보 가져오기

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@
 - [x] /products/:productId/summary api를 사용하여 제품 정보 가져오기
 - [x] 제품 정보 API에서 4XX 에러가 발생하면 Toast를 통해 에러메시지를 보여주고, 선물하기 홈으로 연결
 - [x] 보내는 사람 Input Field에 userInfo의 name을 defaultValue로 채우기
-- [ ] /order api를 사용하여 주문하기 기능을 완성
-- [ ] 주문하기 API의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken을 넣어야만 동작
-- [ ] 주문하기 API에서 401 에러가 발생하면 로그인 페이지로 연결
+- [x] /order api를 사용하여 주문하기 기능을 완성
+- [x] 주문하기 API의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken을 넣어야만 동작
+- [x] 주문하기 API에서 401 에러가 발생하면 로그인 페이지로 연결

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
 - [x] 4XX 에러가 발생하면 Toast를 통해 에러메시지 출력
 
 #### 2. 주문하기 기능
-- [ ] /products/:productId/summary api를 사용하여 제품 정보 가져오기
-- [ ] 제품 정보 API에서 4XX 에러가 발생하면 Toast를 통해 에러메시지를 보여주고, 선물하기 홈으로 연결
+- [x] /products/:productId/summary api를 사용하여 제품 정보 가져오기
+- [x] 제품 정보 API에서 4XX 에러가 발생하면 Toast를 통해 에러메시지를 보여주고, 선물하기 홈으로 연결
 - [ ] 보내는 사람 Input Field에 userInfo의 name을 defaultValue로 채우기
 - [ ] /order api를 사용하여 주문하기 기능을 완성
 - [ ] 주문하기 API의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken을 넣어야만 동작

--- a/README.md
+++ b/README.md
@@ -14,3 +14,20 @@
 - [x] API 명세를 살펴보고 각 필터 선택 시 해당 필터에 맞는 API를 재 요청
 - [x] 데이터를 불러오는 동안 로딩 화면 만들기
 - [x] 보여 줄 상품 목록이 없을경우 상품 목록이 없다는 문구 표시
+
+## 2단계 - 로그인, 주문하기 API 구현하기
+
+### 요구사항
+
+#### 1. 로그인 기능
+- [ ] /login api 를 사용하여 로그인 기능을 완성
+- [ ] 로그인 성공 시 내려오는 authToken과 email, name을 userInfo storage에 저장하고 활용
+- [ ] 4XX 에러가 발생하면 Toast를 통해 에러메시지 출력
+
+#### 2. 주문하기 기능
+- [ ] /products/:productId/summary api를 사용하여 제품 정보 가져오기
+- [ ] 제품 정보 API에서 4XX 에러가 발생하면 Toast를 통해 에러메시지를 보여주고, 선물하기 홈으로 연결
+- [ ] 보내는 사람 Input Field에 userInfo의 name을 defaultValue로 채우기
+- [ ] /order api를 사용하여 주문하기 기능을 완성
+- [ ] 주문하기 API의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken을 넣어야만 동작
+- [ ] 주문하기 API에서 401 에러가 발생하면 로그인 페이지로 연결

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.60.0",
         "react-router": "^7.6.2",
+        "react-toastify": "^11.0.5",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -2136,6 +2137,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3569,6 +3579,19 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.60.0",
     "react-router": "^7.6.2",
+    "react-toastify": "^11.0.5",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,11 +10,14 @@ import LoginPage from "./LoginPage";
 import NotFoundPage from "./NotFoundPage";
 import MyPage from "./MyPage";
 import OrderPage from "./OrderPage";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css"
 
 function App() {
   return (
     <>
       <GlobalStyle />
+      <ToastContainer position="bottom-center" autoClose={3000} />
       <Layout>
         <Header />
         <Routes>

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -7,6 +7,9 @@ import { useInput } from "@/hooks/useInput";
 import { useValidate } from "@/hooks/useValidate";
 import { validateEmail, validatePassword } from "@/utils/validate";
 import { useAuth } from "@/hooks/useAuth";
+import { login } from "@/apis/auth";
+import { toast } from "react-toastify";
+import { AxiosError } from "axios";
 
 const LogoImage = styled.img`
   width: 88px;
@@ -48,16 +51,30 @@ export default function LoginPage() {
   const passwordInput = useInput("");
   const passwordValidation = useValidate(passwordInput.value, validatePassword);
 
-  const handleLogin = () => {
-    const email = emailInput.value;
-    setUser({
-      email,
-      name: email.split("@")[0],
-    });
-    if (window.history.length > 2) {
-      navigate(-1);
-    } else {
-      navigate("/");
+  const handleLogin = async () => {
+    try {
+      const result = await login({
+        email: emailInput.value,
+        password: passwordInput.value,
+      });
+
+      setUser({
+        email: result.email,
+        name: result.name,
+        authToken: result.authToken,
+      });
+
+      if (window.history.length > 2) {
+        navigate(-1);
+      } else {
+        navigate("/");
+      }
+    } catch (error: unknown) {
+      if (error instanceof AxiosError) {
+        toast.error(error.response?.data?.message ?? "@kakao.com 이메일 주소만 가능합니다.");
+      } else {
+        toast.error("알 수 없는 오류가 발생했습니다.");
+      }
     }
   };
 

--- a/src/OrderPage.tsx
+++ b/src/OrderPage.tsx
@@ -17,7 +17,7 @@ import { getProductSummary, type ProductSummary } from "@/apis/product";
 import { toast } from "react-toastify";
 import { AxiosError } from "axios";
 import { useAuth } from "@/hooks/useAuth";
-
+import { orderProduct } from "@/apis/order";
 
 type FormData = z.infer<typeof orderSchema>;
 
@@ -84,17 +84,37 @@ function OrderPage() {
 
   const totalPrice = product ? product.price * totalQuantity : 0;
 
-  const onSubmit = (data: FormData) => {
-    const receiverLines = data.receivers.map((r) => `- ${r.name} / ${r.phone} / 수량: ${r.quantity}`).join("\n");
-    const message = 
-`🎁 ${product?.name} 주문 완료!
-보낸 사람: ${data.sender}
-메시지: ${data.message}
-받는 사람 목록:
-${receiverLines}`;
+  const onSubmit = async (data: FormData) => {
+    if (!product) return;
+    try {
+      await orderProduct({
+        productId: product.id,
+        message: data.message,
+        messageCardId: String(selectedCardId),
+        ordererName: data.sender,
+        receivers: data.receivers.map((r) => ({
+          name: r.name,
+          phoneNumber: r.phone,
+          quantity: r.quantity,
+        })),
+      }, user?.authToken || "");
+      const message =
+        `주문이 완료되었습니다.
+상품명: ${product?.name}
+구매 수량: ${totalQuantity}
+발신자 이름: ${data.sender}
+메시지: ${data.message}`;
 
-    alert(message);
-    navigate("/");
+      alert(message);
+      navigate("/");
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.status === 401) {
+        toast.error("로그인이 필요합니다. 로그인 페이지로 이동합니다.");
+        navigate("/login");
+      } else {
+        toast.error("주문에 실패했습니다. 다시 시도해주세요.")
+      }
+    }
   };
 
   if (!product) {

--- a/src/OrderPage.tsx
+++ b/src/OrderPage.tsx
@@ -16,6 +16,7 @@ import * as z from "zod";
 import { getProductSummary, type ProductSummary } from "@/apis/product";
 import { toast } from "react-toastify";
 import { AxiosError } from "axios";
+import { useAuth } from "@/hooks/useAuth";
 
 
 type FormData = z.infer<typeof orderSchema>;
@@ -54,6 +55,8 @@ function OrderPage() {
   const defaultCardId = messageCardData[0]?.id ?? 1;
   const [selectedCardId, setSelectedCardId] = useState(defaultCardId);
 
+  const { user } = useAuth();
+
   const {
     register,
     handleSubmit,
@@ -70,6 +73,12 @@ function OrderPage() {
       receivers: [],
     },
   });
+
+  useEffect(() => {
+    if (user?.name) {
+      setValue("sender", user.name);
+    }
+  }, [user?.name, setValue]);
 
   const totalQuantity = watch("receivers").reduce((sum, r) => sum + (r.quantity || 0), 0);
 

--- a/src/OrderPage.tsx
+++ b/src/OrderPage.tsx
@@ -6,14 +6,16 @@ import ReceiverModalSection from "@/sections/OrderSection/ReceiverModalSection";
 import ProductInfoSection from "@/sections/OrderSection/ProductInfoSection";
 import BottomOrderBar from "@/sections/OrderSection/BottomOrderBar";
 import { useParams, useNavigate } from "react-router";
-import { giftRankingData } from "@/mocks/giftRankingData";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { messageCardData } from "@/mocks/messageCardData";
 import { withAuth } from "@/hoc/withAuth";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { orderSchema, type OrderFormData } from "@/utils/validateOrderSchema";
 import * as z from "zod";
+import { getProductSummary, type ProductSummary } from "@/apis/product";
+import { toast } from "react-toastify";
+import { AxiosError } from "axios";
 
 
 type FormData = z.infer<typeof orderSchema>;
@@ -22,9 +24,32 @@ function OrderPage() {
   const navigate = useNavigate();
   const { id } = useParams();
 
-  const rank = Number(id);
-  const repeatedData = Array(12).fill(null).flatMap(() => giftRankingData);
-  const product = repeatedData[rank - 1];
+  const productId = Number(id);
+  const [product, setProduct] = useState<ProductSummary | null>(null);
+
+  useEffect(() => {
+    if (isNaN(productId)) {
+      navigate("/");
+      return;
+    }
+
+    const fetchProduct = async () => {
+      try {
+        const data = await getProductSummary(productId);
+        setProduct(data);
+      } catch (error: unknown) {
+        if (error instanceof AxiosError) {
+          toast.error(error.response?.data?.message ?? "상품 정보를 불러올 수 없습니다.");
+        } else {
+          toast.error("알 수 없는 오류가 발생했습니다.");
+        }
+        navigate("/");
+      }
+    };
+
+    fetchProduct();
+  }, [productId, navigate]);
+
 
   const defaultCardId = messageCardData[0]?.id ?? 1;
   const [selectedCardId, setSelectedCardId] = useState(defaultCardId);
@@ -48,12 +73,12 @@ function OrderPage() {
 
   const totalQuantity = watch("receivers").reduce((sum, r) => sum + (r.quantity || 0), 0);
 
-  const totalPrice = product?.price.sellingPrice * totalQuantity;
+  const totalPrice = product ? product.price * totalQuantity : 0;
 
   const onSubmit = (data: FormData) => {
     const receiverLines = data.receivers.map((r) => `- ${r.name} / ${r.phone} / 수량: ${r.quantity}`).join("\n");
     const message = 
-`🎁 ${rank}등 상품 주문 완료!
+`🎁 ${product?.name} 주문 완료!
 보낸 사람: ${data.sender}
 메시지: ${data.message}
 받는 사람 목록:
@@ -63,7 +88,7 @@ ${receiverLines}`;
     navigate("/");
   };
 
-  if (!product || isNaN(rank) || rank < 1 || rank > repeatedData.length) {
+  if (!product) {
     return <PageContainer>존재하지 않는 상품입니다.</PageContainer>;
   }
 
@@ -95,8 +120,8 @@ ${receiverLines}`;
           product={{
             imageUrl: product.imageURL,
             name: product.name,
-            brand: product.brandInfo.name,
-            price: product.price.sellingPrice,
+            brand: product.brandName,
+            price: product.price,
           }}
         />
         <BottomOrderBar totalPrice={totalPrice} isValid onOrder={handleSubmit(onSubmit)} />

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,17 @@
+import axiosInstance from "./axiosInstance";
+
+interface LoginBody {
+    email: string;
+    password: string;
+}
+
+interface LoginResponse {
+    email: string;
+    name: string;
+    authToken: string;
+}
+
+export async function login(body: LoginBody): Promise<LoginResponse> {
+    const res = await axiosInstance.post<{ data: LoginResponse }>("/api/login", body);
+    return res.data.data;
+}

--- a/src/apis/order.ts
+++ b/src/apis/order.ts
@@ -1,0 +1,21 @@
+import axiosInstance from "./axiosInstance";
+
+export interface OrderRequest {
+    productId: number;
+    message: string;
+    messageCardId: string;
+    ordererName: string;
+    receivers: {
+        name: string;
+        phoneNumber: string;
+        quantity: number;
+    }[];
+}
+
+export async function orderProduct(data: OrderRequest, authToken: string): Promise<void> {
+    await axiosInstance.post("/api/order", data, {
+        headers: {
+            Authorization: authToken,
+        },
+    });
+}

--- a/src/apis/product.ts
+++ b/src/apis/product.ts
@@ -1,0 +1,14 @@
+import axiosInstance from "./axiosInstance";
+
+export interface ProductSummary {
+    id: number;
+    name: string;
+    brandName: string;
+    price: number;
+    imageURL: string;
+}
+
+export async function getProductSummary(productId: number): Promise<ProductSummary> {
+    const res = await axiosInstance.get<{ data: ProductSummary }>(`/api/products/${productId}/summary`);
+    return res.data.data;
+}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -58,7 +58,7 @@ export default function ProductCard({ item, rank }: ProductCardProps) {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(`/order/${rank}`);
+    navigate(`/order/${item.id}`);
   }
   return (
     <Card onClick={handleClick}>

--- a/src/contexts/AuthContext.ts
+++ b/src/contexts/AuthContext.ts
@@ -3,6 +3,7 @@ import { createContext } from "react";
 export interface User {
   email: string;
   name: string;
+  authToken: string;
 }
 
 export interface AuthContextType {


### PR DESCRIPTION
안녕하세요 멘토님! 2단계 구현을 마쳐 PR 드립니다
일단, 이번 과제의 요구사항입니다.

1. 로그인 기능
 - /login api 를 사용하여 로그인 기능을 완성
 - 로그인 성공 시 내려오는 authToken과 email, name을 userInfo storage에 저장하고 활용
 - 4XX 에러가 발생하면 Toast를 통해 에러메시지 출력

2. 주문하기 기능
 - /products/:productId/summary api를 사용하여 제품 정보 가져오기
 - 제품 정보 API에서 4XX 에러가 발생하면 Toast를 통해 에러메시지를 보여주고, 선물하기 홈으로 연결
 - 보내는 사람 Input Field에 userInfo의 name을 defaultValue로 채우기
 - /order api를 사용하여 주문하기 기능을 완성
 - 주문하기 API의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken을 넣어야만 동작
 - 주문하기 API에서 401 에러가 발생하면 로그인 페이지로 연결

product는 사용자가 입력하거나 제출하는 폼 입력값이 아니므로 react-hook-form으로 관리하지 않고 useState<ProductSummary | null>(null)로 관리하는 방식을 사용하였습니다.