### PR TITLE
강원대 FE 허태웅 - 2단계 로그인, 주문하기 API 구현하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@
 ## 2 단계 - 로그인, 주문하기 API 구현하기
 
 - [ ] 로그인 기능
-  - [ ] `/login` api 를 사용하여 로그인 기능을 완성
-  - [ ] 로그인 성공 시 내려오는 authToken 과 email, name 을 userInfo storage 에 저장
+  - [x] `/api/login` api 를 사용하여 로그인 기능을 완성
+  - [x] 로그인 성공 시 내려오는 authToken 과 email, name 을 userInfo storage 에 저장
   - [ ] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 띄움
     - [react-toastify](https://www.npmjs.com/package/react-toastify) 라이브러리 사용
 - [ ] 주문하기 기능

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@
 - [ ] 주문하기 기능
   - [x] `/products/:productsId/summary` api 를 사용하여 제품 정보를 가져오기
   - [x] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 보여주고, 선물하기 홈으로 연결
-  - [ ] 보내는 사람 Input Field 에 userInfo 의 name 을 defaultValue 로 채우기
+  - [x] 보내는 사람 Input Field 에 userInfo 의 name 을 defaultValue 로 채우기
   - [ ] `/order` api 를 사용하여 주문하기 기능을 완성
     - [ ] 주문하기 api 의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken 을 넣어야 함
     - [ ] 주문하기 api 에서 401 에러가 발생하면 로그인 페이지로 연결

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@
   - [x] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 띄움
     - [react-toastify](https://www.npmjs.com/package/react-toastify) 라이브러리 사용
 - [ ] 주문하기 기능
-  - [ ] `/products/:productsId/summary` api 를 사용하여 제품 정보를 가져오기
+  - [x] `/products/:productsId/summary` api 를 사용하여 제품 정보를 가져오기
   - [ ] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 보여주고, 선물하기 홈으로 연결
   - [ ] 보내는 사람 Input Field 에 userInfo 의 name 을 defaultValue 로 채우기
   - [ ] `/order` api 를 사용하여 주문하기 기능을 완성

--- a/README.md
+++ b/README.md
@@ -110,3 +110,18 @@
   - [x] 필터 선택 시 해당 필터에 맞는 API 를 재요청
   - [x] 데이터를 불러오는 동안 로딩 화면 구현
   - [x] 보여 줄 상품 목록이 없을경우 상품목록이 없다는 문구
+
+## 2 단계 - 로그인, 주문하기 API 구현하기
+
+- [ ] 로그인 기능
+  - [ ] `/login` api 를 사용하여 로그인 기능을 완성
+  - [ ] 로그인 성공 시 내려오는 authToken 과 email, name 을 userInfo storage 에 저장
+  - [ ] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 띄움
+    - [react-toastify](https://www.npmjs.com/package/react-toastify) 라이브러리 사용
+- [ ] 주문하기 기능
+  - [ ] `/products/:productsId/summary` api 를 사용하여 제품 정보를 가져오기
+  - [ ] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 보여주고, 선물하기 홈으로 연결
+  - [ ] 보내는 사람 Input Field 에 userInfo 의 name 을 defaultValue 로 채우기
+  - [ ] `/order` api 를 사용하여 주문하기 기능을 완성
+    - [ ] 주문하기 api 의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken 을 넣어야 함
+    - [ ] 주문하기 api 에서 401 에러가 발생하면 로그인 페이지로 연결

--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@
   - [x] 로그인 성공 시 내려오는 authToken 과 email, name 을 userInfo storage 에 저장
   - [x] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 띄움
     - [react-toastify](https://www.npmjs.com/package/react-toastify) 라이브러리 사용
-- [ ] 주문하기 기능
+- [x] 주문하기 기능
   - [x] `/api/products/:productsId/summary` api 를 사용하여 제품 정보를 가져오기
   - [x] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 보여주고, 선물하기 홈으로 연결
   - [x] 보내는 사람 Input Field 에 userInfo 의 name 을 defaultValue 로 채우기
-  - [ ] `/api/order` api 를 사용하여 주문하기 기능을 완성
+  - [x] `/api/order` api 를 사용하여 주문하기 기능을 완성
     - [x] 주문하기 api 의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken 을 넣어야 함
-    - [ ] 주문하기 api 에서 401 에러가 발생하면 로그인 페이지로 연결
+    - [x] 주문하기 api 에서 401 에러가 발생하면 로그인 페이지로 연결

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@
 
 ## 2 단계 - 로그인, 주문하기 API 구현하기
 
-- [ ] 로그인 기능
+- [x] 로그인 기능
   - [x] `/api/login` api 를 사용하여 로그인 기능을 완성
   - [x] 로그인 성공 시 내려오는 authToken 과 email, name 을 userInfo storage 에 저장
-  - [ ] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 띄움
+  - [x] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 띄움
     - [react-toastify](https://www.npmjs.com/package/react-toastify) 라이브러리 사용
 - [ ] 주문하기 기능
   - [ ] `/products/:productsId/summary` api 를 사용하여 제품 정보를 가져오기

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@
     - [react-toastify](https://www.npmjs.com/package/react-toastify) 라이브러리 사용
 - [ ] 주문하기 기능
   - [x] `/products/:productsId/summary` api 를 사용하여 제품 정보를 가져오기
-  - [ ] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 보여주고, 선물하기 홈으로 연결
+  - [x] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 보여주고, 선물하기 홈으로 연결
   - [ ] 보내는 사람 Input Field 에 userInfo 의 name 을 defaultValue 로 채우기
   - [ ] `/order` api 를 사용하여 주문하기 기능을 완성
     - [ ] 주문하기 api 의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken 을 넣어야 함

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@
   - [x] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 띄움
     - [react-toastify](https://www.npmjs.com/package/react-toastify) 라이브러리 사용
 - [ ] 주문하기 기능
-  - [x] `/products/:productsId/summary` api 를 사용하여 제품 정보를 가져오기
+  - [x] `/api/products/:productsId/summary` api 를 사용하여 제품 정보를 가져오기
   - [x] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 보여주고, 선물하기 홈으로 연결
   - [x] 보내는 사람 Input Field 에 userInfo 의 name 을 defaultValue 로 채우기
-  - [ ] `/order` api 를 사용하여 주문하기 기능을 완성
-    - [ ] 주문하기 api 의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken 을 넣어야 함
+  - [ ] `/api/order` api 를 사용하여 주문하기 기능을 완성
+    - [x] 주문하기 api 의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken 을 넣어야 함
     - [ ] 주문하기 api 에서 401 에러가 발생하면 로그인 페이지로 연결

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.60.0",
         "react-router-dom": "^7.6.3",
+        "react-toastify": "^11.0.5",
         "zod": "^4.0.2"
       },
       "devDependencies": {
@@ -2166,6 +2167,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3609,6 +3619,19 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.60.0",
     "react-router-dom": "^7.6.3",
+    "react-toastify": "^11.0.5",
     "zod": "^4.0.2"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import { AuthProvider } from "./contexts/AuthContext";
 import MyPage from "./pages/MyPage/MyPage";
 import { ROUTES } from "./constants/routes";
 import OrderPage from "./pages/OrderPage/OrderPage";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 const globalStyles = css`
   body {
@@ -32,6 +34,12 @@ function App() {
           </Routes>
         </ViewportContainer>
       </AuthProvider>
+      <ToastContainer
+        position="bottom-center"
+        newestOnTop={false}
+        closeOnClick
+        hideProgressBar={true}
+      />
     </ThemeProvider>
   );
 }

--- a/src/constants/httpStatus.ts
+++ b/src/constants/httpStatus.ts
@@ -1,0 +1,28 @@
+export const HTTP_STATUS = {
+  OK: 200,
+  CREATED: 201,
+  NO_CONTENT: 204,
+
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  UNPROCESSABLE_ENTITY: 422,
+
+  INTERNAL_SERVER_ERROR: 500,
+  BAD_GATEWAY: 502,
+  SERVICE_UNAVAILABLE: 503,
+} as const;
+
+export const isClientError = (status: number): boolean => {
+  return status >= 400 && status < 500;
+};
+
+export const isServerError = (status: number): boolean => {
+  return status >= 500 && status < 600;
+};
+
+export const isUnauthorized = (status: number): boolean => {
+  return status === HTTP_STATUS.UNAUTHORIZED;
+};

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,8 +1,6 @@
+import type { User } from "@/types/User";
+import { getUserName } from "@/utils/auth";
 import { createContext, useContext, useState } from "react";
-
-interface User {
-  email: string;
-}
 
 type AuthState =
   | { user: null; isLoggedIn: false }
@@ -37,7 +35,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [authState, setAuthState] = useState<AuthState>(getInitialAuthState());
 
   const login = (email: string) => {
-    const newUser: User = { email };
+    const newUser: User = { email, name: getUserName(email), authToken: "" };
 
     setAuthState({
       user: newUser,

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,4 @@
 import type { User } from "@/types/User";
-import { getUserName } from "@/utils/auth";
 import { createContext, useContext, useState } from "react";
 
 type AuthState =
@@ -7,7 +6,7 @@ type AuthState =
   | { user: User; isLoggedIn: true };
 
 type AuthContextType = AuthState & {
-  login: (email: string) => void;
+  login: (email: string, name: string, authToken: string) => void;
   logout: () => void;
 };
 
@@ -34,8 +33,8 @@ const getInitialAuthState = (): AuthState => {
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [authState, setAuthState] = useState<AuthState>(getInitialAuthState());
 
-  const login = (email: string) => {
-    const newUser: User = { email, name: getUserName(email), authToken: "" };
+  const login = (email: string, name: string, authToken: string) => {
+    const newUser: User = { email, name, authToken };
 
     setAuthState({
       user: newUser,

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -3,7 +3,7 @@ import { END_POINTS } from "./endPoints";
 import type { GiftThemeType } from "@/types/GiftThemeType";
 import type { TrendingGiftsType } from "@/types/TrendingGiftsType";
 import type { User } from "@/types/User";
-import type { ProductInfoSummary } from "@/pages/OrderPage/components/ProductInfo/ProductInfo";
+import type { ProductInfoSummary } from "@/types/ProductInfoSummary";
 
 export const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -52,9 +52,8 @@ export const getProductInfo = async (
 export const createOrder = async (authToken: string, order: Order) => {
   const response = await apiClient.post("/api/order", order, {
     headers: {
-      Authorization: `Bearer ${authToken}`,
+      Authorization: authToken,
     },
   });
-  console.log(response);
   return response.data.data;
 };

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -4,6 +4,7 @@ import type { GiftThemeType } from "@/types/GiftThemeType";
 import type { TrendingGiftsType } from "@/types/TrendingGiftsType";
 import type { User } from "@/types/User";
 import type { ProductInfoSummary } from "@/types/ProductInfoSummary";
+import type { Order } from "@/types/Order";
 
 export const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -45,5 +46,15 @@ export const getProductInfo = async (
   id: string
 ): Promise<ProductInfoSummary> => {
   const response = await apiClient.get(`/api/products/${id}/summary`);
+  return response.data.data;
+};
+
+export const createOrder = async (authToken: string, order: Order) => {
+  const response = await apiClient.post("/api/order", order, {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  });
+  console.log(response);
   return response.data.data;
 };

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import { END_POINTS } from "./endPoints";
 import type { GiftThemeType } from "@/types/GiftThemeType";
 import type { TrendingGiftsType } from "@/types/TrendingGiftsType";
+import type { User } from "@/types/User";
 
 export const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -24,6 +25,17 @@ export const getTrendingGifts = async (
       targetType,
       rankType,
     },
+  });
+  return response.data.data;
+};
+
+export const getUserInfo = async (
+  email: string,
+  password: string
+): Promise<User> => {
+  const response = await apiClient.post("/api/login", {
+    email,
+    password,
   });
   return response.data.data;
 };

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -35,7 +35,7 @@ export const getUserInfo = async (
   email: string,
   password: string
 ): Promise<User> => {
-  const response = await apiClient.post("/api/login", {
+  const response = await apiClient.post(END_POINTS.LOGIN, {
     email,
     password,
   });
@@ -45,12 +45,14 @@ export const getUserInfo = async (
 export const getProductInfo = async (
   id: string
 ): Promise<ProductInfoSummary> => {
-  const response = await apiClient.get(`/api/products/${id}/summary`);
+  const response = await apiClient.get(
+    END_POINTS.PRODUCT_INFO.replace(":id", id)
+  );
   return response.data.data;
 };
 
 export const createOrder = async (authToken: string, order: Order) => {
-  const response = await apiClient.post("/api/order", order, {
+  const response = await apiClient.post(END_POINTS.ORDER, order, {
     headers: {
       Authorization: authToken,
     },

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -3,6 +3,7 @@ import { END_POINTS } from "./endPoints";
 import type { GiftThemeType } from "@/types/GiftThemeType";
 import type { TrendingGiftsType } from "@/types/TrendingGiftsType";
 import type { User } from "@/types/User";
+import type { ProductInfoSummary } from "@/pages/OrderPage/components/ProductInfo/ProductInfo";
 
 export const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -37,5 +38,12 @@ export const getUserInfo = async (
     email,
     password,
   });
+  return response.data.data;
+};
+
+export const getProductInfo = async (
+  id: string
+): Promise<ProductInfoSummary> => {
+  const response = await apiClient.get(`/api/products/${id}/summary`);
   return response.data.data;
 };

--- a/src/data/endPoints.ts
+++ b/src/data/endPoints.ts
@@ -1,4 +1,7 @@
 export const END_POINTS = {
   THEMES: "/api/themes",
   RANKING: "/api/products/ranking",
+  LOGIN: "/api/login",
+  PRODUCT_INFO: "/api/products/:id/summary",
+  ORDER: "/api/order",
 } as const;

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -38,7 +38,7 @@ export function useFetch<T>({
           isLoading: false,
           isError: true,
         });
-        return;
+        return null;
       }
 
       setFetchState({
@@ -46,6 +46,8 @@ export function useFetch<T>({
         isLoading: false,
         isError: false,
       });
+
+      return data;
     } catch (error) {
       errorHandler(error);
 
@@ -54,6 +56,8 @@ export function useFetch<T>({
         isLoading: false,
         isError: true,
       });
+
+      throw error;
     }
   };
 

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -2,9 +2,10 @@ import { useState, useEffect } from "react";
 import type { FetchState } from "@/types/FetchState";
 
 interface UseFetchOptions<T> {
-  fetchFn: () => Promise<T[]>;
+  fetchFn: () => Promise<T>;
   errorHandler: (error: unknown) => void;
-  validateData?: ((data: T[]) => boolean)[];
+  enabled?: boolean;
+  validateData?: ((data: T) => boolean)[];
   deps?: React.DependencyList;
 }
 
@@ -12,6 +13,7 @@ export function useFetch<T>({
   fetchFn,
   validateData,
   errorHandler,
+  enabled = true,
   deps = [],
 }: UseFetchOptions<T>) {
   const [fetchState, setFetchState] = useState<FetchState<T>>({
@@ -20,50 +22,50 @@ export function useFetch<T>({
     isError: false,
   });
 
-  useEffect(() => {
-    const executeFetch = async () => {
-      setFetchState({
-        data: null,
-        isLoading: true,
-        isError: false,
-      });
+  const executeFetch = async () => {
+    setFetchState({
+      data: null,
+      isLoading: true,
+      isError: false,
+    });
 
-      try {
-        const data = await fetchFn();
+    try {
+      const data = await fetchFn();
 
-        if (
-          validateData &&
-          !validateData.every((validator) => validator(data))
-        ) {
-          setFetchState({
-            data: null,
-            isLoading: false,
-            isError: true,
-          });
-          return;
-        }
-
-        setFetchState({
-          data,
-          isLoading: false,
-          isError: false,
-        });
-      } catch (error) {
-        errorHandler(error);
-
+      if (validateData && !validateData.every((validator) => validator(data))) {
         setFetchState({
           data: null,
           isLoading: false,
           isError: true,
         });
+        return;
       }
-    };
 
+      setFetchState({
+        data,
+        isLoading: false,
+        isError: false,
+      });
+    } catch (error) {
+      errorHandler(error);
+
+      setFetchState({
+        data: null,
+        isLoading: false,
+        isError: true,
+      });
+    }
+  };
+
+  useEffect(() => {
     // deps가 배열 리터럴이 아닌 변수이기 때문에 생기는 경고
-    executeFetch();
+    if (enabled) {
+      executeFetch();
+    }
   }, deps);
 
   return {
     ...fetchState,
+    executeFetch,
   };
 }

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -3,15 +3,15 @@ import type { FetchState } from "@/types/FetchState";
 
 interface UseFetchOptions<T> {
   fetchFn: () => Promise<T[]>;
-  errorMessage: string;
+  errorHandler: (error: unknown) => void;
   validateData?: ((data: T[]) => boolean)[];
   deps?: React.DependencyList;
 }
 
 export function useFetch<T>({
   fetchFn,
-  errorMessage,
   validateData,
+  errorHandler,
   deps = [],
 }: UseFetchOptions<T>) {
   const [fetchState, setFetchState] = useState<FetchState<T>>({
@@ -49,7 +49,7 @@ export function useFetch<T>({
           isError: false,
         });
       } catch (error) {
-        console.error(errorMessage, error);
+        errorHandler(error);
 
         setFetchState({
           data: null,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,12 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
-import App from './App.tsx';
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
       <App />
     </BrowserRouter>
-  </StrictMode>,
+  </StrictMode>
 );

--- a/src/pages/HomePage/components/Category/Category.tsx
+++ b/src/pages/HomePage/components/Category/Category.tsx
@@ -17,7 +17,9 @@ import type { GiftThemeType } from "@/types/GiftThemeType";
 function CategoryContent() {
   const { data, isLoading, isError } = useFetch<GiftThemeType>({
     fetchFn: getThemes,
-    errorMessage: CATEGORY_ERROR_MESSAGE.DATA_LOADING_ERROR,
+    errorHandler: () => {
+      console.error(CATEGORY_ERROR_MESSAGE.DATA_LOADING_ERROR);
+    },
     validateData: [(data) => data.length > 0],
   });
 

--- a/src/pages/HomePage/components/Category/Category.tsx
+++ b/src/pages/HomePage/components/Category/Category.tsx
@@ -15,7 +15,7 @@ import { useFetch } from "@/hooks/useFetch";
 import type { GiftThemeType } from "@/types/GiftThemeType";
 
 function CategoryContent() {
-  const { data, isLoading, isError } = useFetch<GiftThemeType>({
+  const { data, isLoading, isError } = useFetch<GiftThemeType[]>({
     fetchFn: getThemes,
     errorHandler: () => {
       console.error(CATEGORY_ERROR_MESSAGE.DATA_LOADING_ERROR);

--- a/src/pages/HomePage/components/TrendingGifts/TrendingGifts.tsx
+++ b/src/pages/HomePage/components/TrendingGifts/TrendingGifts.tsx
@@ -31,7 +31,9 @@ function TrendingGiftsContent() {
   const { data, isLoading, isError } = useFetch<TrendingGiftsType>({
     fetchFn: () =>
       getTrendingGifts(TARGET_TYPE[mainTabIdx], RANK_TYPE[subTabIdx]),
-    errorMessage: TRENDING_GIFTS_ERROR_MESSAGES.FETCH_ERROR,
+    errorHandler: () => {
+      console.error(TRENDING_GIFTS_ERROR_MESSAGES.FETCH_ERROR);
+    },
     deps: [mainTabIdx, subTabIdx],
   });
 

--- a/src/pages/HomePage/components/TrendingGifts/TrendingGifts.tsx
+++ b/src/pages/HomePage/components/TrendingGifts/TrendingGifts.tsx
@@ -28,7 +28,7 @@ function TrendingGiftsContent() {
   const [mainTabIdx, setMainTabIdx] = useMainTab();
   const [subTabIdx, setSubTabIdx] = useSubTab();
 
-  const { data, isLoading, isError } = useFetch<TrendingGiftsType>({
+  const { data, isLoading, isError } = useFetch<TrendingGiftsType[]>({
     fetchFn: () =>
       getTrendingGifts(TARGET_TYPE[mainTabIdx], RANK_TYPE[subTabIdx]),
     errorHandler: () => {

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -21,8 +21,6 @@ export interface LoginFormProps {
 }
 
 function LoginPage() {
-  const { handleSubmit } = useLoginSubmit();
-
   const { email, handleEmailValueChange, validateEmail, emailErrorMessage } =
     useEmailValidation();
 
@@ -33,6 +31,8 @@ function LoginPage() {
     passwordErrorMessage,
   } = usePasswordValidation();
 
+  const { handleSubmit } = useLoginSubmit({ email, password });
+
   const isValidEmail = !emailErrorMessage && email.trim() !== "";
   const isValidPassword = !passwordErrorMessage && password.trim() !== "";
 
@@ -42,7 +42,7 @@ function LoginPage() {
     <Layout>
       <LoginContainer>
         <KakaoLogo>kakao</KakaoLogo>
-        <LoginForm onSubmit={(e) => handleSubmit(e, email, password)}>
+        <LoginForm onSubmit={(e) => handleSubmit(e)}>
           <InputFieldGroup>
             <IDField
               value={email}

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -42,7 +42,7 @@ function LoginPage() {
     <Layout>
       <LoginContainer>
         <KakaoLogo>kakao</KakaoLogo>
-        <LoginForm onSubmit={(e) => handleSubmit(e, email)}>
+        <LoginForm onSubmit={(e) => handleSubmit(e, email, password)}>
           <InputFieldGroup>
             <IDField
               value={email}

--- a/src/pages/LoginPage/constants/apiMessage.ts
+++ b/src/pages/LoginPage/constants/apiMessage.ts
@@ -1,0 +1,3 @@
+export const API_LOGIN_ERROR_MESSAGES = {
+  EMAIL_FORMAT_INVALID: "@kakao.com 이메일 주소만 가능합니다.",
+} as const;

--- a/src/pages/LoginPage/constants/labels.ts
+++ b/src/pages/LoginPage/constants/labels.ts
@@ -10,3 +10,7 @@ export const LOGIN_ERROR_MESSAGES = {
   PASSWORD_EMPTY: "PW를 입력해주세요.",
   PASSWORD_FORMAT_INVALID: "PW는 최소 8자 이상이어야 합니다.",
 } as const;
+
+export const API_LOGIN_ERROR_MESSAGES = {
+  EMAIL_FORMAT_INVALID: "@kakao.com 이메일 주소만 가능합니다.",
+} as const;

--- a/src/pages/LoginPage/constants/labels.ts
+++ b/src/pages/LoginPage/constants/labels.ts
@@ -10,7 +10,3 @@ export const LOGIN_ERROR_MESSAGES = {
   PASSWORD_EMPTY: "PW를 입력해주세요.",
   PASSWORD_FORMAT_INVALID: "PW는 최소 8자 이상이어야 합니다.",
 } as const;
-
-export const API_LOGIN_ERROR_MESSAGES = {
-  EMAIL_FORMAT_INVALID: "@kakao.com 이메일 주소만 가능합니다.",
-} as const;

--- a/src/pages/LoginPage/hooks/useLoginSubmit.ts
+++ b/src/pages/LoginPage/hooks/useLoginSubmit.ts
@@ -1,16 +1,28 @@
 import { ROUTES } from "@/constants/routes";
 import { useAuth } from "@/contexts/AuthContext";
+import { getUserInfo } from "@/data/api";
 import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
 
 function useLoginSubmit() {
   const navigate = useNavigate();
   const location = useLocation();
   const [searchParams] = useSearchParams();
+
   const { login } = useAuth();
 
-  const handleSubmit = (e: React.FormEvent, email: string) => {
+  const handleSubmit = async (
+    e: React.FormEvent,
+    email: string,
+    password: string
+  ) => {
     e.preventDefault();
-    login(email);
+
+    try {
+      const response = await getUserInfo(email, password);
+      login(response.email, response.name, response.authToken);
+    } catch (error) {
+      console.error(error);
+    }
 
     const redirectPath = searchParams.get("redirect");
     const from = redirectPath || location.state?.from || ROUTES.HOME;

--- a/src/pages/LoginPage/hooks/useLoginSubmit.ts
+++ b/src/pages/LoginPage/hooks/useLoginSubmit.ts
@@ -1,7 +1,9 @@
 import { ROUTES } from "@/constants/routes";
 import { useAuth } from "@/contexts/AuthContext";
 import { getUserInfo } from "@/data/api";
+import { AxiosError } from "axios";
 import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
+import { toast } from "react-toastify";
 
 function useLoginSubmit() {
   const navigate = useNavigate();
@@ -21,7 +23,14 @@ function useLoginSubmit() {
       const response = await getUserInfo(email, password);
       login(response.email, response.name, response.authToken);
     } catch (error) {
-      console.error(error);
+      if (error instanceof AxiosError) {
+        const errorStatus = error.response?.status;
+
+        if (errorStatus && errorStatus >= 400 && errorStatus < 500) {
+          toast.error("@kakao.com 이메일 주소만 가능합니다.");
+        }
+      }
+      return;
     }
 
     const redirectPath = searchParams.get("redirect");

--- a/src/pages/LoginPage/hooks/useLoginSubmit.ts
+++ b/src/pages/LoginPage/hooks/useLoginSubmit.ts
@@ -4,6 +4,7 @@ import { getUserInfo } from "@/data/api";
 import { AxiosError } from "axios";
 import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
 import { toast } from "react-toastify";
+import { API_LOGIN_ERROR_MESSAGES } from "../constants/labels";
 
 function useLoginSubmit() {
   const navigate = useNavigate();
@@ -27,7 +28,7 @@ function useLoginSubmit() {
         const errorStatus = error.response?.status;
 
         if (errorStatus && errorStatus >= 400 && errorStatus < 500) {
-          toast.error("@kakao.com 이메일 주소만 가능합니다.");
+          toast.error(API_LOGIN_ERROR_MESSAGES.EMAIL_FORMAT_INVALID);
         }
       }
       return;

--- a/src/pages/LoginPage/hooks/useLoginSubmit.ts
+++ b/src/pages/LoginPage/hooks/useLoginSubmit.ts
@@ -7,6 +7,7 @@ import { toast } from "react-toastify";
 import { API_LOGIN_ERROR_MESSAGES } from "../constants/apiMessage";
 import type { User } from "@/types/User";
 import { useFetch } from "@/hooks/useFetch";
+import { isClientError } from "@/constants/httpStatus";
 
 interface UseLoginSubmitProps {
   email: string;
@@ -24,7 +25,7 @@ function useLoginSubmit({ email, password }: UseLoginSubmitProps) {
       if (error instanceof AxiosError) {
         const errorStatus = error.response?.status;
 
-        if (errorStatus && errorStatus >= 400 && errorStatus < 500) {
+        if (errorStatus && isClientError(errorStatus)) {
           toast.error(API_LOGIN_ERROR_MESSAGES.EMAIL_FORMAT_INVALID);
         }
       }

--- a/src/pages/LoginPage/hooks/useLoginSubmit.ts
+++ b/src/pages/LoginPage/hooks/useLoginSubmit.ts
@@ -4,7 +4,7 @@ import { getUserInfo } from "@/data/api";
 import { AxiosError } from "axios";
 import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
 import { toast } from "react-toastify";
-import { API_LOGIN_ERROR_MESSAGES } from "../constants/labels";
+import { API_LOGIN_ERROR_MESSAGES } from "../constants/apiMessage";
 
 function useLoginSubmit() {
   const navigate = useNavigate();

--- a/src/pages/LoginPage/hooks/useLoginSubmit.ts
+++ b/src/pages/LoginPage/hooks/useLoginSubmit.ts
@@ -5,25 +5,22 @@ import { AxiosError } from "axios";
 import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import { API_LOGIN_ERROR_MESSAGES } from "../constants/apiMessage";
+import type { User } from "@/types/User";
+import { useFetch } from "@/hooks/useFetch";
 
-function useLoginSubmit() {
+interface UseLoginSubmitProps {
+  email: string;
+  password: string;
+}
+
+function useLoginSubmit({ email, password }: UseLoginSubmitProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const [searchParams] = useSearchParams();
 
-  const { login } = useAuth();
-
-  const handleSubmit = async (
-    e: React.FormEvent,
-    email: string,
-    password: string
-  ) => {
-    e.preventDefault();
-
-    try {
-      const response = await getUserInfo(email, password);
-      login(response.email, response.name, response.authToken);
-    } catch (error) {
+  const { data, executeFetch } = useFetch<User>({
+    fetchFn: () => getUserInfo(email, password),
+    errorHandler: (error) => {
       if (error instanceof AxiosError) {
         const errorStatus = error.response?.status;
 
@@ -31,13 +28,25 @@ function useLoginSubmit() {
           toast.error(API_LOGIN_ERROR_MESSAGES.EMAIL_FORMAT_INVALID);
         }
       }
-      return;
+    },
+    enabled: false,
+  });
+
+  const { login } = useAuth();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    await executeFetch();
+
+    if (data) {
+      login(data.email, data.name, data.authToken);
+
+      const redirectPath = searchParams.get("redirect");
+      const from = redirectPath || location.state?.from || ROUTES.HOME;
+
+      navigate(from, { replace: true });
     }
-
-    const redirectPath = searchParams.get("redirect");
-    const from = redirectPath || location.state?.from || ROUTES.HOME;
-
-    navigate(from, { replace: true });
   };
 
   return { handleSubmit };

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -8,7 +8,7 @@ import ProductInfo from "./components/ProductInfo/ProductInfo";
 import { useProductInfo } from "./hooks/useProductInfo";
 import { ROUTES } from "@/constants/routes";
 import { useNavigate } from "react-router-dom";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useOrderForm } from "./hooks/useOrderForm";
 import { ORDER_MESSAGES } from "./constants/alert";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
@@ -17,6 +17,8 @@ import { useAuth } from "@/contexts/AuthContext";
 import type { Order } from "@/types/Order";
 import { createOrder } from "@/data/api";
 import { AxiosError } from "axios";
+import { useFetch } from "@/hooks/useFetch";
+import { API_ERROR_MESSAGES } from "./constants/apiMessage";
 
 const OrderPageContainer = styled.div`
   display: flex;
@@ -30,6 +32,32 @@ function OrderPage() {
   const [isSubmittedOnce, setIsSubmittedOnce] = useState(false);
   const { product, loading } = useProductInfo();
   const { user } = useAuth();
+
+  const [order, setOrder] = useState<Order | null>(null);
+
+  const { data } = useFetch<{ success: boolean }>({
+    fetchFn: () => {
+      if (!order) {
+        return Promise.reject(new Error(API_ERROR_MESSAGES.ORDER_NOT_FOUND));
+      }
+      return createOrder(user?.authToken || "", order);
+    },
+    errorHandler: (error) => {
+      if (error instanceof AxiosError) {
+        if (error.response?.status === 401) {
+          navigate(ROUTES.LOGIN);
+        }
+      }
+    },
+    enabled: !!order, // order가 있을 때만 실행
+    deps: [order], // order가 변경되면 자동 실행
+  });
+
+  useEffect(() => {
+    if (data && data.success) {
+      navigate(ROUTES.HOME);
+    }
+  }, [data, navigate]);
 
   const {
     messageCard,
@@ -72,7 +100,7 @@ function OrderPage() {
         quantity: Number(receiver.quantity),
       }));
 
-      const order: Order = {
+      const orderData: Order = {
         productId: product?.id || 0,
         message: formValues.cardMessage,
         messageCardId: messageCard.id.toString(),
@@ -80,18 +108,7 @@ function OrderPage() {
         receivers: transformedReceivers,
       };
 
-      try {
-        await createOrder(user?.authToken || "", order);
-      } catch (error) {
-        if (error instanceof AxiosError) {
-          if (error.response?.status === 401) {
-            navigate(ROUTES.LOGIN);
-            return;
-          }
-        }
-      }
-
-      navigate(ROUTES.HOME);
+      setOrder(orderData);
       return;
     }
   };

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -77,12 +77,7 @@ function OrderPage() {
     );
   }
 
-  if (!loading && !product) {
-    navigate(ROUTES.NOT_FOUND);
-    return null;
-  }
-
-  if (!product) {
+  if (loading || !product) {
     return null;
   }
 

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -66,10 +66,8 @@ function OrderPage() {
         })
       );
 
-      // receivers의 quantity를 string에서 number로 변환
       const transformedReceivers = receivers.map((receiver) => ({
-        name: receiver.name,
-        phoneNumber: receiver.phoneNumber,
+        ...receiver,
         quantity: Number(receiver.quantity),
       }));
 
@@ -80,8 +78,6 @@ function OrderPage() {
         ordererName: formValues.senderName,
         receivers: transformedReceivers,
       };
-
-      console.log(order);
 
       try {
         const response = await createOrder(user?.authToken || "", order);

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -66,12 +66,19 @@ function OrderPage() {
         })
       );
 
+      // receivers의 quantity를 string에서 number로 변환
+      const transformedReceivers = receivers.map((receiver) => ({
+        name: receiver.name,
+        phoneNumber: receiver.phoneNumber,
+        quantity: Number(receiver.quantity),
+      }));
+
       const order: Order = {
         productId: product?.id || 0,
         message: formValues.cardMessage,
         messageCardId: messageCard.id.toString(),
         ordererName: formValues.senderName,
-        receivers: receivers,
+        receivers: transformedReceivers,
       };
 
       console.log(order);

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -13,6 +13,9 @@ import { useOrderForm } from "./hooks/useOrderForm";
 import { ORDER_MESSAGES } from "./constants/alert";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { LoadingContainer } from "../HomePage/components/Category/Category.styles";
+import { useAuth } from "@/contexts/AuthContext";
+import type { Order } from "@/types/Order";
+import { createOrder } from "@/data/api";
 
 const OrderPageContainer = styled.div`
   display: flex;
@@ -25,6 +28,7 @@ function OrderPage() {
   const navigate = useNavigate();
   const [isSubmittedOnce, setIsSubmittedOnce] = useState(false);
   const { product, loading } = useProductInfo();
+  const { user } = useAuth();
 
   const {
     messageCard,
@@ -61,6 +65,23 @@ function OrderPage() {
           cardMessage: formValues.cardMessage,
         })
       );
+
+      const order: Order = {
+        productId: product?.id || 0,
+        message: formValues.cardMessage,
+        messageCardId: messageCard.id.toString(),
+        ordererName: formValues.senderName,
+        receivers: receivers,
+      };
+
+      console.log(order);
+
+      try {
+        const response = await createOrder(user?.authToken || "", order);
+        console.log(response);
+      } catch (error) {
+        console.error(error);
+      }
 
       navigate(ROUTES.HOME);
       return;

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -11,6 +11,8 @@ import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { useOrderForm } from "./hooks/useOrderForm";
 import { ORDER_MESSAGES } from "./constants/alert";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { LoadingContainer } from "../HomePage/components/Category/Category.styles";
 
 const OrderPageContainer = styled.div`
   display: flex;
@@ -22,7 +24,7 @@ const OrderPageContainer = styled.div`
 function OrderPage() {
   const navigate = useNavigate();
   const [isSubmittedOnce, setIsSubmittedOnce] = useState(false);
-  const product = useProductInfo();
+  const { product, loading } = useProductInfo();
 
   const {
     messageCard,
@@ -65,9 +67,23 @@ function OrderPage() {
     }
   };
 
-  if (!product) {
+  if (loading) {
+    return (
+      <Layout>
+        <LoadingContainer>
+          <LoadingSpinner />
+        </LoadingContainer>
+      </Layout>
+    );
+  }
+
+  if (!loading && !product) {
     navigate(ROUTES.NOT_FOUND);
-    return;
+    return null;
+  }
+
+  if (!product) {
+    return null;
   }
 
   const totalQuantity = receivers.reduce(

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -6,19 +6,11 @@ import SenderSectionComponent from "./components/SenderSection/SenderSection";
 import ReceiverSectionComponent from "./components/ReceiverSection/ReceiverSection";
 import ProductInfo from "./components/ProductInfo/ProductInfo";
 import { useProductInfo } from "./hooks/useProductInfo";
-import { ROUTES } from "@/constants/routes";
-import { useNavigate } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useOrderForm } from "./hooks/useOrderForm";
-import { ORDER_MESSAGES } from "./constants/alert";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { LoadingContainer } from "../HomePage/components/Category/Category.styles";
-import { useAuth } from "@/contexts/AuthContext";
-import type { Order } from "@/types/Order";
-import { createOrder } from "@/data/api";
-import { AxiosError } from "axios";
-import { useFetch } from "@/hooks/useFetch";
-import { API_ERROR_MESSAGES } from "./constants/apiMessage";
+import { useOrderSubmit } from "./hooks/useOrderSubmit";
 
 const OrderPageContainer = styled.div`
   display: flex;
@@ -28,36 +20,8 @@ const OrderPageContainer = styled.div`
 `;
 
 function OrderPage() {
-  const navigate = useNavigate();
   const [isSubmittedOnce, setIsSubmittedOnce] = useState(false);
   const { product, loading } = useProductInfo();
-  const { user } = useAuth();
-
-  const [order, setOrder] = useState<Order | null>(null);
-
-  const { data } = useFetch<{ success: boolean }>({
-    fetchFn: () => {
-      if (!order) {
-        return Promise.reject(new Error(API_ERROR_MESSAGES.ORDER_NOT_FOUND));
-      }
-      return createOrder(user?.authToken || "", order);
-    },
-    errorHandler: (error) => {
-      if (error instanceof AxiosError) {
-        if (error.response?.status === 401) {
-          navigate(ROUTES.LOGIN);
-        }
-      }
-    },
-    enabled: !!order, // order가 있을 때만 실행
-    deps: [order], // order가 변경되면 자동 실행
-  });
-
-  useEffect(() => {
-    if (data && data.success) {
-      navigate(ROUTES.HOME);
-    }
-  }, [data, navigate]);
 
   const {
     messageCard,
@@ -75,43 +39,14 @@ function OrderPage() {
     getFormValues,
   } = useOrderForm({ isSubmittedOnce });
 
-  const onSubmitHandler = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    const isValid = await validateAllForms();
-
-    if (!isValid) {
-      setIsSubmittedOnce(true);
-    }
-
-    if (isValid) {
-      const formValues = getFormValues();
-      alert(
-        ORDER_MESSAGES.ORDER_COMPLETE_TEMPLATE({
-          productName: product?.name || "",
-          totalQuantity: formValues.totalQuantity,
-          senderName: formValues.senderName,
-          cardMessage: formValues.cardMessage,
-        })
-      );
-
-      const transformedReceivers = receivers.map((receiver) => ({
-        ...receiver,
-        quantity: Number(receiver.quantity),
-      }));
-
-      const orderData: Order = {
-        productId: product?.id || 0,
-        message: formValues.cardMessage,
-        messageCardId: messageCard.id.toString(),
-        ordererName: formValues.senderName,
-        receivers: transformedReceivers,
-      };
-
-      setOrder(orderData);
-      return;
-    }
-  };
+  const { onSubmitHandler } = useOrderSubmit({
+    validateAllForms,
+    setIsSubmittedOnce,
+    getFormValues,
+    receivers,
+    messageCard,
+    product,
+  });
 
   if (loading) {
     return (

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -16,6 +16,7 @@ import { LoadingContainer } from "../HomePage/components/Category/Category.style
 import { useAuth } from "@/contexts/AuthContext";
 import type { Order } from "@/types/Order";
 import { createOrder } from "@/data/api";
+import { AxiosError } from "axios";
 
 const OrderPageContainer = styled.div`
   display: flex;
@@ -80,10 +81,14 @@ function OrderPage() {
       };
 
       try {
-        const response = await createOrder(user?.authToken || "", order);
-        console.log(response);
+        await createOrder(user?.authToken || "", order);
       } catch (error) {
-        console.error(error);
+        if (error instanceof AxiosError) {
+          if (error.response?.status === 401) {
+            navigate(ROUTES.LOGIN);
+            return;
+          }
+        }
       }
 
       navigate(ROUTES.HOME);

--- a/src/pages/OrderPage/components/ProductInfo/ProductInfo.tsx
+++ b/src/pages/OrderPage/components/ProductInfo/ProductInfo.tsx
@@ -1,3 +1,4 @@
+import type { ProductInfoSummary } from "@/types/ProductInfoSummary";
 import { PRODUCT_INFO_CONSTANTS } from "../../constants/productInfo";
 import {
   ProductSection,
@@ -17,14 +18,6 @@ import {
 interface ProductInfoProps {
   product: ProductInfoSummary;
   quantity: string;
-}
-
-export interface ProductInfoSummary {
-  id: number;
-  name: string;
-  brandName: string;
-  price: number;
-  imageURL: string;
 }
 
 function ProductInfo({ product, quantity }: ProductInfoProps) {

--- a/src/pages/OrderPage/components/ProductInfo/ProductInfo.tsx
+++ b/src/pages/OrderPage/components/ProductInfo/ProductInfo.tsx
@@ -13,15 +13,22 @@ import {
   OrderButtonContainer,
   OrderButton,
 } from "./ProductInfo.styles";
-import type { TrendingGiftsType } from "@/types/TrendingGiftsType";
 
 interface ProductInfoProps {
-  product: TrendingGiftsType;
+  product: ProductInfoSummary;
   quantity: string;
 }
 
+export interface ProductInfoSummary {
+  id: number;
+  name: string;
+  brandName: string;
+  price: number;
+  imageURL: string;
+}
+
 function ProductInfo({ product, quantity }: ProductInfoProps) {
-  const totalPrice = product.price.sellingPrice * parseInt(quantity, 10);
+  const totalPrice = product.price * parseInt(quantity, 10);
 
   return (
     <>
@@ -31,11 +38,11 @@ function ProductInfo({ product, quantity }: ProductInfoProps) {
           <ProductImage src={product.imageURL} alt={product.name} />
           <ProductDetails>
             <ProductName>{product.name}</ProductName>
-            <BrandName>{product.brandInfo.name}</BrandName>
+            <BrandName>{product.brandName}</BrandName>
             <PriceContainer>
               <PriceLabel>{PRODUCT_INFO_CONSTANTS.PRICE_LABEL}</PriceLabel>
               <Price>
-                {product.price.sellingPrice.toLocaleString()}
+                {product.price.toLocaleString()}
                 {PRODUCT_INFO_CONSTANTS.WON}
               </Price>
             </PriceContainer>

--- a/src/pages/OrderPage/components/ReceiverSection/ReceiverModal/ReceiverForm.tsx
+++ b/src/pages/OrderPage/components/ReceiverSection/ReceiverModal/ReceiverForm.tsx
@@ -23,7 +23,7 @@ import Input from "@/components/common/Input/Input";
 interface FormData {
   receivers: {
     name: string;
-    phone: string;
+    phoneNumber: string;
     quantity: string;
   }[];
 }
@@ -98,11 +98,11 @@ function ReceiverForm({
         />
         <LabeledInputField
           fieldLabel={RECEIVER_SECTION_CONSTANTS.PHONE_LABEL}
-          name={`receivers.${index}.phone`}
+          name={`receivers.${index}.phoneNumber`}
           control={control}
           type="tel"
           placeholder={RECEIVER_SECTION_CONSTANTS.PHONE_PLACEHOLDER}
-          errorMessage={errors.receivers?.[index]?.phone?.message}
+          errorMessage={errors.receivers?.[index]?.phoneNumber?.message}
         />
         <LabeledInputField
           fieldLabel={RECEIVER_SECTION_CONSTANTS.QUANTITY_LABEL}

--- a/src/pages/OrderPage/components/ReceiverSection/ReceiverModal/ReceiverModal.tsx
+++ b/src/pages/OrderPage/components/ReceiverSection/ReceiverModal/ReceiverModal.tsx
@@ -5,7 +5,6 @@ import {
   RECEIVER_MODAL_CONSTANTS,
   DEFAULT_RECEIVER,
 } from "../../../constants/receiverSection";
-import type { Receiver } from "../../../hooks/useOrderForm";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FORM_FIELD } from "../../../constants/formField";
 import { receiversSchema } from "../../../schemas";
@@ -24,6 +23,7 @@ import {
   CompleteButton,
   ReceiverList,
 } from "./ReceiverModal.styles";
+import type { Receiver } from "@/types/Receiver";
 
 interface FormData {
   receivers: Receiver[];

--- a/src/pages/OrderPage/components/ReceiverSection/ReceiverSection.tsx
+++ b/src/pages/OrderPage/components/ReceiverSection/ReceiverSection.tsx
@@ -38,7 +38,7 @@ function ReceiverSectionComponent({
     <ReceiverSection>
       <ReceiverSectionHeader>
         <SectionTitle>{RECEIVER_SECTION_CONSTANTS.TITLE}</SectionTitle>
-        <ShowModalButton onClick={handleOpenModal}>
+        <ShowModalButton type="button" onClick={handleOpenModal}>
           {RECEIVER_MODIFIY_BUTTON}
         </ShowModalButton>
       </ReceiverSectionHeader>

--- a/src/pages/OrderPage/components/ReceiverSection/ReceiverSection.tsx
+++ b/src/pages/OrderPage/components/ReceiverSection/ReceiverSection.tsx
@@ -13,7 +13,7 @@ import { useState } from "react";
 import ReceiverModal from "./ReceiverModal/ReceiverModal";
 import ReceiverTable from "./ReceiverTable/ReceiverTable";
 import NoReceiver from "./NoReceiver/NoReceiver";
-import type { Receiver } from "../../hooks/useOrderForm";
+import type { Receiver } from "@/types/Receiver";
 
 interface ReceiverSectionComponentProps {
   receivers: Receiver[];

--- a/src/pages/OrderPage/components/ReceiverSection/ReceiverTable/ReceiverTable.tsx
+++ b/src/pages/OrderPage/components/ReceiverSection/ReceiverTable/ReceiverTable.tsx
@@ -1,4 +1,4 @@
-import type { Receiver } from "../../../hooks/useOrderForm";
+import type { Receiver } from "@/types/Receiver";
 import { TABLE_CELL_CONSTANTS } from "../../../constants/table";
 import {
   ReceiverTableContainer,
@@ -21,9 +21,9 @@ function ReceiverTable({ receivers }: ReceiverTableProps) {
         <TableHeaderCell>{TABLE_CELL_CONSTANTS.QUANTITY}</TableHeaderCell>
       </TableHeader>
       {receivers.map((receiver) => (
-        <TableRow key={receiver.phone}>
+        <TableRow key={receiver.phoneNumber}>
           <TableCell>{receiver.name}</TableCell>
-          <TableCell>{receiver.phone}</TableCell>
+          <TableCell>{receiver.phoneNumber}</TableCell>
           <TableCell>{receiver.quantity}</TableCell>
         </TableRow>
       ))}

--- a/src/pages/OrderPage/constants/apiMessage.ts
+++ b/src/pages/OrderPage/constants/apiMessage.ts
@@ -1,0 +1,3 @@
+export const API_ERROR_MESSAGES = {
+  PRODUCT_NOT_FOUND: "현재 없는 상품입니다",
+} as const;

--- a/src/pages/OrderPage/constants/apiMessage.ts
+++ b/src/pages/OrderPage/constants/apiMessage.ts
@@ -1,3 +1,4 @@
 export const API_ERROR_MESSAGES = {
   PRODUCT_NOT_FOUND: "현재 없는 상품입니다",
+  ORDER_NOT_FOUND: "주문 정보가 없습니다",
 } as const;

--- a/src/pages/OrderPage/constants/receiverSection.ts
+++ b/src/pages/OrderPage/constants/receiverSection.ts
@@ -31,8 +31,8 @@ export const MAX_RECEIVERS: number = 10;
 
 export const DEFAULT_RECEIVER = {
   name: "",
-  phone: "",
-  quantity: "",
+  phoneNumber: "",
+  quantity: 0,
 } as const;
 
 export const RECEIVER_MODIFIY_BUTTON = "수정";

--- a/src/pages/OrderPage/constants/receiverSection.ts
+++ b/src/pages/OrderPage/constants/receiverSection.ts
@@ -32,7 +32,7 @@ export const MAX_RECEIVERS: number = 10;
 export const DEFAULT_RECEIVER = {
   name: "",
   phoneNumber: "",
-  quantity: 0,
+  quantity: "",
 } as const;
 
 export const RECEIVER_MODIFIY_BUTTON = "수정";

--- a/src/pages/OrderPage/hooks/useOrderForm.ts
+++ b/src/pages/OrderPage/hooks/useOrderForm.ts
@@ -9,7 +9,7 @@ import {
   type SenderFormData,
 } from "../schemas";
 import { FORM_FIELD } from "../constants/formField";
-import SENDER_SECTION_CONSTANTS from "../constants/senderSection";
+import { useAuth } from "@/contexts/AuthContext";
 
 interface UseOrderFormProps {
   isSubmittedOnce: boolean;
@@ -22,6 +22,7 @@ export interface Receiver {
 }
 
 export const useOrderForm = ({ isSubmittedOnce }: UseOrderFormProps) => {
+  const { user } = useAuth();
   const [receivers, setReceivers] = useState<Receiver[]>([]);
 
   const {
@@ -59,7 +60,7 @@ export const useOrderForm = ({ isSubmittedOnce }: UseOrderFormProps) => {
   } = useForm<SenderFormData>({
     mode: isSubmittedOnce ? "onChange" : "onSubmit",
     defaultValues: {
-      senderName: SENDER_SECTION_CONSTANTS.DEFAULT_SENDER_NAME,
+      senderName: user?.name,
     },
     resolver: zodResolver(senderSchema),
   });

--- a/src/pages/OrderPage/hooks/useOrderForm.ts
+++ b/src/pages/OrderPage/hooks/useOrderForm.ts
@@ -10,15 +10,10 @@ import {
 } from "../schemas";
 import { FORM_FIELD } from "../constants/formField";
 import { useAuth } from "@/contexts/AuthContext";
+import type { Receiver } from "@/types/Receiver";
 
 interface UseOrderFormProps {
   isSubmittedOnce: boolean;
-}
-
-export interface Receiver {
-  name: string;
-  phone: string;
-  quantity: string;
 }
 
 export const useOrderForm = ({ isSubmittedOnce }: UseOrderFormProps) => {

--- a/src/pages/OrderPage/hooks/useOrderSubmit.ts
+++ b/src/pages/OrderPage/hooks/useOrderSubmit.ts
@@ -1,0 +1,105 @@
+import { useAuth } from "@/contexts/AuthContext";
+import { createOrder } from "@/data/api";
+import { useFetch } from "@/hooks/useFetch";
+import type { Order } from "@/types/Order";
+import type { Receiver } from "@/types/Receiver";
+import type { OrderCardType } from "@/types/OrderCardType";
+import type { ProductInfoSummary } from "@/types/ProductInfoSummary";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { API_ERROR_MESSAGES } from "../constants/apiMessage";
+import { AxiosError } from "axios";
+import { ROUTES } from "@/constants/routes";
+import { ORDER_MESSAGES } from "../constants/alert";
+
+interface UseOrderSubmitProps {
+  validateAllForms: () => Promise<boolean>;
+  setIsSubmittedOnce: React.Dispatch<React.SetStateAction<boolean>>;
+  getFormValues: () => {
+    senderName: string;
+    cardMessage: string;
+    totalQuantity: number;
+  };
+  receivers: Receiver[];
+  messageCard: OrderCardType;
+  product: ProductInfoSummary | null;
+}
+
+export const useOrderSubmit = ({
+  validateAllForms,
+  setIsSubmittedOnce,
+  getFormValues,
+  receivers,
+  messageCard,
+  product,
+}: UseOrderSubmitProps) => {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [order, setOrder] = useState<Order | null>(null);
+
+  const { data } = useFetch<{ success: boolean }>({
+    fetchFn: () => {
+      if (!order) {
+        return Promise.reject(new Error(API_ERROR_MESSAGES.ORDER_NOT_FOUND));
+      }
+      return createOrder(user?.authToken || "", order);
+    },
+    errorHandler: (error) => {
+      if (error instanceof AxiosError) {
+        if (error.response?.status === 401) {
+          navigate(ROUTES.LOGIN);
+        }
+      }
+    },
+    enabled: !!order, // order가 있을 때만 실행
+    deps: [order], // order가 변경되면 자동 실행
+  });
+
+  useEffect(() => {
+    if (data && data.success) {
+      navigate(ROUTES.HOME);
+    }
+  }, [data, navigate]);
+
+  const onSubmitHandler = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const isValid = await validateAllForms();
+
+    if (!isValid) {
+      setIsSubmittedOnce(true);
+    }
+
+    if (isValid) {
+      const formValues = getFormValues();
+      alert(
+        ORDER_MESSAGES.ORDER_COMPLETE_TEMPLATE({
+          productName: product?.name || "",
+          totalQuantity: formValues.totalQuantity,
+          senderName: formValues.senderName,
+          cardMessage: formValues.cardMessage,
+        })
+      );
+
+      const transformedReceivers = receivers.map((receiver) => ({
+        ...receiver,
+        quantity: Number(receiver.quantity),
+      }));
+
+      const orderData: Order = {
+        productId: product?.id || 0,
+        message: formValues.cardMessage,
+        messageCardId: messageCard.id.toString(),
+        ordererName: formValues.senderName,
+        receivers: transformedReceivers,
+      };
+
+      setOrder(orderData);
+      return;
+    }
+  };
+
+  return {
+    onSubmitHandler,
+  };
+};

--- a/src/pages/OrderPage/hooks/useOrderSubmit.ts
+++ b/src/pages/OrderPage/hooks/useOrderSubmit.ts
@@ -11,6 +11,7 @@ import { API_ERROR_MESSAGES } from "../constants/apiMessage";
 import { AxiosError } from "axios";
 import { ROUTES } from "@/constants/routes";
 import { ORDER_MESSAGES } from "../constants/alert";
+import { isUnauthorized } from "@/constants/httpStatus";
 
 interface UseOrderSubmitProps {
   validateAllForms: () => Promise<boolean>;
@@ -46,7 +47,7 @@ export const useOrderSubmit = ({
     },
     errorHandler: (error) => {
       if (error instanceof AxiosError) {
-        if (error.response?.status === 401) {
+        if (error.response?.status && isUnauthorized(error.response?.status)) {
           navigate(ROUTES.LOGIN);
         }
       }

--- a/src/pages/OrderPage/hooks/useProductInfo.ts
+++ b/src/pages/OrderPage/hooks/useProductInfo.ts
@@ -1,7 +1,10 @@
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { getProductInfo } from "@/data/api";
 import type { ProductInfoSummary } from "@/types/ProductInfoSummary";
+import { toast } from "react-toastify";
+import { ROUTES } from "@/constants/routes";
+import { AxiosError } from "axios";
 
 export function useProductInfo(): {
   product: ProductInfoSummary | null;
@@ -10,6 +13,7 @@ export function useProductInfo(): {
   const { id } = useParams<{ id: string }>();
   const [product, setProduct] = useState<ProductInfoSummary | null>(null);
   const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!id) {
@@ -24,15 +28,24 @@ export function useProductInfo(): {
         const productData = await getProductInfo(id);
         setProduct(productData);
       } catch (error) {
-        console.error("상품 없음:", error);
-        setProduct(null);
+        if (error instanceof AxiosError) {
+          const errorStatus = error.response?.status;
+
+          if (errorStatus && errorStatus >= 400 && errorStatus < 500) {
+            toast.error("현재 없는 상품입니다");
+          }
+
+          setProduct(null);
+          navigate(ROUTES.HOME);
+        }
+        return;
       } finally {
         setLoading(false);
       }
     };
 
     fetchProduct();
-  }, [id]);
+  }, [id, navigate]);
 
   return { product, loading };
 }

--- a/src/pages/OrderPage/hooks/useProductInfo.ts
+++ b/src/pages/OrderPage/hooks/useProductInfo.ts
@@ -5,6 +5,7 @@ import type { ProductInfoSummary } from "@/types/ProductInfoSummary";
 import { toast } from "react-toastify";
 import { ROUTES } from "@/constants/routes";
 import { AxiosError } from "axios";
+import { API_ERROR_MESSAGES } from "../constants/apiMessage";
 
 export function useProductInfo(): {
   product: ProductInfoSummary | null;
@@ -32,7 +33,7 @@ export function useProductInfo(): {
           const errorStatus = error.response?.status;
 
           if (errorStatus && errorStatus >= 400 && errorStatus < 500) {
-            toast.error("현재 없는 상품입니다");
+            toast.error(API_ERROR_MESSAGES.PRODUCT_NOT_FOUND);
           }
 
           setProduct(null);

--- a/src/pages/OrderPage/hooks/useProductInfo.ts
+++ b/src/pages/OrderPage/hooks/useProductInfo.ts
@@ -1,7 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { getProductInfo } from "@/data/api";
-import type { ProductInfoSummary } from "../components/ProductInfo/ProductInfo";
+import type { ProductInfoSummary } from "@/types/ProductInfoSummary";
 
 export function useProductInfo(): {
   product: ProductInfoSummary | null;

--- a/src/pages/OrderPage/hooks/useProductInfo.ts
+++ b/src/pages/OrderPage/hooks/useProductInfo.ts
@@ -1,16 +1,38 @@
 import { useParams } from "react-router-dom";
-import { trendingGiftsMockData } from "@/data/trendingGfitsMockData";
-import type { TrendingGiftsType } from "@/types/TrendingGiftsType";
+import { useState, useEffect } from "react";
+import { getProductInfo } from "@/data/api";
+import type { ProductInfoSummary } from "../components/ProductInfo/ProductInfo";
 
-export function useProductInfo(): TrendingGiftsType | null {
+export function useProductInfo(): {
+  product: ProductInfoSummary | null;
+  loading: boolean;
+} {
   const { id } = useParams<{ id: string }>();
+  const [product, setProduct] = useState<ProductInfoSummary | null>(null);
+  const [loading, setLoading] = useState(true);
 
-  if (!id) return null;
+  useEffect(() => {
+    if (!id) {
+      setLoading(false);
+      setProduct(null);
+      return;
+    }
 
-  // 현재는 mock 데이터로 대체
-  const product = trendingGiftsMockData.find(
-    (item) => item.id === parseInt(id, 10)
-  );
+    const fetchProduct = async () => {
+      try {
+        setLoading(true);
+        const productData = await getProductInfo(id);
+        setProduct(productData);
+      } catch (error) {
+        console.error("상품 없음:", error);
+        setProduct(null);
+      } finally {
+        setLoading(false);
+      }
+    };
 
-  return product || null;
+    fetchProduct();
+  }, [id]);
+
+  return { product, loading };
 }

--- a/src/pages/OrderPage/schemas.ts
+++ b/src/pages/OrderPage/schemas.ts
@@ -29,7 +29,7 @@ export const senderSchema = z.object({
 
 export const receiverItemSchema = z.object({
   name: z.string().nonempty(RECEIVER_SECTION_CONSTANTS.NAME_ERROR),
-  phone: z
+  phoneNumber: z
     .string()
     .nonempty(RECEIVER_SECTION_CONSTANTS.PHONE_ERROR)
     .refine(
@@ -44,17 +44,17 @@ export const receiversSchema = z.object({
     const phoneNumberSet = new Set<string>();
 
     receivers.forEach((receiver, index) => {
-      if (receiver.phone && phoneNumberSet.has(receiver.phone)) {
+      if (receiver.phoneNumber && phoneNumberSet.has(receiver.phoneNumber)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: VALIDATE_LABELS.PHONE_DUPLICATE,
-          path: [index, "phone"],
+          path: [index, "phoneNumber"],
         });
 
         return;
       }
 
-      phoneNumberSet.add(receiver.phone);
+      phoneNumberSet.add(receiver.phoneNumber);
     });
   }),
 });

--- a/src/types/FetchState.ts
+++ b/src/types/FetchState.ts
@@ -1,5 +1,5 @@
 export interface FetchState<T> {
-  data: T[] | null;
+  data: T | null;
   isLoading: boolean;
   isError: boolean;
 }

--- a/src/types/Order.ts
+++ b/src/types/Order.ts
@@ -1,9 +1,13 @@
-import type { Receiver } from "./Receiver";
+interface OrderReceiver {
+  name: string;
+  phoneNumber: string;
+  quantity: number;
+}
 
 export interface Order {
   productId: number;
   message: string;
   messageCardId: string;
   ordererName: string;
-  receivers: Receiver[];
+  receivers: OrderReceiver[];
 }

--- a/src/types/Order.ts
+++ b/src/types/Order.ts
@@ -1,0 +1,9 @@
+import type { Receiver } from "./Receiver";
+
+export interface Order {
+  productId: number;
+  message: string;
+  messageCardId: string;
+  ordererName: string;
+  receivers: Receiver[];
+}

--- a/src/types/ProductInfoSummary.ts
+++ b/src/types/ProductInfoSummary.ts
@@ -1,0 +1,7 @@
+export interface ProductInfoSummary {
+  id: number;
+  name: string;
+  brandName: string;
+  price: number;
+  imageURL: string;
+}

--- a/src/types/Receiver.ts
+++ b/src/types/Receiver.ts
@@ -1,5 +1,5 @@
 export interface Receiver {
   name: string;
   phoneNumber: string;
-  quantity: number;
+  quantity: string;
 }

--- a/src/types/Receiver.ts
+++ b/src/types/Receiver.ts
@@ -1,0 +1,5 @@
+export interface Receiver {
+  name: string;
+  phoneNumber: string;
+  quantity: number;
+}

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,5 @@
+export interface User {
+  email: string;
+  name: string;
+  authToken: string;
+}


### PR DESCRIPTION
2단계 로그인, 주문하기 API 구현하기 완료했습니다.

## 2 단계 - 로그인, 주문하기 API 구현하기

- [x] 로그인 기능
  - [x] `/api/login` api 를 사용하여 로그인 기능을 완성
  - [x] 로그인 성공 시 내려오는 authToken 과 email, name 을 userInfo storage 에 저장
  - [x] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 띄움
    - [react-toastify](https://www.npmjs.com/package/react-toastify) 라이브러리 사용
- [x] 주문하기 기능
  - [x] `/api/products/:productsId/summary` api 를 사용하여 제품 정보를 가져오기
  - [x] 4XX 에러가 발생하면 Toast 를 통해 에러 메시지를 보여주고, 선물하기 홈으로 연결
  - [x] 보내는 사람 Input Field 에 userInfo 의 name 을 defaultValue 로 채우기
  - [x] `/api/order` api 를 사용하여 주문하기 기능을 완성
    - [x] 주문하기 api 의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken 을 넣어야 함
    - [x] 주문하기 api 에서 401 에러가 발생하면 로그인 페이지로 연결