### PR TITLE
강원대 FE 유다연 - 2단계 로그인, 주문하기 API 구현하기

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=/api

--- a/README.md
+++ b/README.md
@@ -28,3 +28,23 @@
   - [x] API 명세를 살펴보고 각 필터 선택 시 해당 필터에 맞는 API를 재요청하기
   - [x] 데이터를 불러오는 동안 로딩 화면 만들기
   - [x] 보여 줄 상품 목록이 없을 경우 상품 목록이 없다는 문구 보여주기
+
+  <br />
+
+---
+
+<br />
+
+## ✅ 2단계 - 로그인, 주문하기 API 구현하기
+
+- **로그인 기능**
+  - [x] /login api 를 사용하여 로그인 기능 완성하기
+  - [x] 로그인 성공 시 내려오는 authToken과 email, name을 userInfo storage에 저장하고 활용하기
+  - [x] 4XX 에러가 발생하면 Toast를 통해 에러메시지를 보여주기 (react-toastify 라이브러리 사용)
+- **주문하기 기능**
+  - [x] /products/:productId/summary api를 사용하여 제품 정보를 가져오기
+  - [x] 만약 제품 정보 API에서 4XX 에러가 발생하면 Toast를 통해 에러메시지를 보여주고, 선물하기 홈으로 연결시키기
+  - [x] 보내는 사람 Input Field에 userInfo의 name을 defaultValue로 채워놓기
+  - [x] /order api를 사용하여 주문하기 기능을 완성하기
+  - [x] 주문하기 API의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken을 넣어야만 동작하도록 하기
+  - [x] 주문하기 API에서 401 에러가 발생하면 로그인 페이지로 연결시키기

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-hook-form": "^7.60.0",
         "react-router": "^7.6.3",
         "react-router-dom": "^7.6.3",
+        "react-toastify": "^11.0.5",
         "zod": "^4.0.5"
       },
       "devDependencies": {
@@ -2428,6 +2429,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3923,6 +3933,19 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-hook-form": "^7.60.0",
     "react-router": "^7.6.3",
     "react-router-dom": "^7.6.3",
+    "react-toastify": "^11.0.5",
     "zod": "^4.0.5"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { globalStyle } from '@/styles/GlobalStyle'
 import { RouterProvider } from 'react-router-dom'
 import { UserProvider } from '@/contexts/UserContext'
 import Router from '@/routes/Router'
+import { ToastContainer } from 'react-toastify'
 
 const App = () => {
   return (
@@ -11,6 +12,13 @@ const App = () => {
       <UserProvider>
         <RouterProvider router={Router} />
       </UserProvider>
+
+      <ToastContainer
+        position="bottom-center"
+        autoClose={2000}
+        hideProgressBar={false}
+        closeOnClick
+      />
     </>
   )
 }

--- a/src/component/TopNavigationBar/TopNavigationBar.tsx
+++ b/src/component/TopNavigationBar/TopNavigationBar.tsx
@@ -8,7 +8,7 @@ import { ROUTE_PATH } from '@/routes/Router'
 const TopNavigationBar: React.FC = () => {
   const navigate = useNavigate()
   const location = useLocation()
-  const { isLoggedIn } = useUserContext()
+  const { user } = useUserContext()
 
   const handleGoBack = () => {
     if (window.history.length > 1) {
@@ -19,7 +19,7 @@ const TopNavigationBar: React.FC = () => {
   }
 
   const handleGoLogin = () => {
-    const targetPath = isLoggedIn ? ROUTE_PATH.MY : ROUTE_PATH.LOGIN
+    const targetPath = !!user ? ROUTE_PATH.MY : ROUTE_PATH.LOGIN
     if (location.pathname !== targetPath) navigate(targetPath)
   }
 

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,51 +1,43 @@
 import { createContext, useContext, useState } from 'react'
-
 import type { ReactNode } from 'react'
 
 interface User {
   email: string
   nickname: string
+  authToken: string
 }
 
 interface UserContextType {
-  isLoggedIn: boolean
   user: User | null
   login: (userInfo: User) => void
   logout: () => void
 }
 
 const STORAGE_KEY = {
-  IS_LOGGED_IN: 'isLoggedIn',
-  USER: 'user',
+  USER: 'kakaotech/userInfo',
 }
 
 const UserContext = createContext<UserContextType | null>(null)
 
 export const UserProvider = ({ children }: { children: ReactNode }) => {
-  const storedLogin =
-    sessionStorage.getItem(STORAGE_KEY.IS_LOGGED_IN) === 'true'
   const storedUser = sessionStorage.getItem(STORAGE_KEY.USER)
 
-  const [isLoggedIn, setIsLoggedIn] = useState(storedLogin)
   const [user, setUser] = useState<User | null>(
     storedUser ? JSON.parse(storedUser) : null
   )
 
   const login = (userInfo: User) => {
-    sessionStorage.setItem(STORAGE_KEY.IS_LOGGED_IN, 'true')
     sessionStorage.setItem(STORAGE_KEY.USER, JSON.stringify(userInfo))
-    setIsLoggedIn(true)
     setUser(userInfo)
   }
 
   const logout = () => {
-    sessionStorage.clear()
-    setIsLoggedIn(false)
+    sessionStorage.removeItem(STORAGE_KEY.USER)
     setUser(null)
   }
 
   return (
-    <UserContext.Provider value={{ isLoggedIn, user, login, logout }}>
+    <UserContext.Provider value={{ user, login, logout }}>
       {children}
     </UserContext.Provider>
   )
@@ -53,6 +45,7 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
 
 export const useUserContext = () => {
   const context = useContext(UserContext)
-  if (!context) throw new Error('useUserContext는 UserProvider 안에서만 사용')
+  if (!context)
+    throw new Error('useUserContext는 UserProvider 안에서만 사용해야 합니다.')
   return context
 }

--- a/src/features/Gift/components/GiftCategory/GiftCategory.tsx
+++ b/src/features/Gift/components/GiftCategory/GiftCategory.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import * as S from './GiftCategory.styles'
 import Loading from '@/component/Loading/Loading'
-import { useThemes } from '../../hooks/useThemes'
+import { useThemes } from '@/features/Gift/hooks/useThemes'
 
 const GiftCategory = () => {
   const { themes, loading, error } = useThemes()
@@ -11,26 +11,24 @@ const GiftCategory = () => {
     navigate(`/themes/${themeId}`)
   }
 
+  if (loading) return <Loading />
+  if (error || themes.length === 0) return null
+
   return (
-    <>
-      {loading && <Loading />}
-      {!loading && !error && themes.length > 0 && (
-        <S.Container>
-          <S.Title>선물 테마</S.Title>
-          <S.Grid>
-            {themes.map((theme) => (
-              <S.Item
-                key={theme.themeId}
-                onClick={() => handleSelect(theme.themeId)}
-              >
-                <S.ItemImage src={theme.image} alt={theme.name} />
-                <S.ItemName>{theme.name}</S.ItemName>
-              </S.Item>
-            ))}
-          </S.Grid>
-        </S.Container>
-      )}
-    </>
+    <S.Container>
+      <S.Title>선물 테마</S.Title>
+      <S.Grid>
+        {themes.map((theme) => (
+          <S.Item
+            key={theme.themeId}
+            onClick={() => handleSelect(theme.themeId)}
+          >
+            <S.ItemImage src={theme.image} alt={theme.name} />
+            <S.ItemName>{theme.name}</S.ItemName>
+          </S.Item>
+        ))}
+      </S.Grid>
+    </S.Container>
   )
 }
 

--- a/src/features/Gift/components/GiftRecipient/GiftRecipient.tsx
+++ b/src/features/Gift/components/GiftRecipient/GiftRecipient.tsx
@@ -2,12 +2,12 @@ import * as S from './GiftRecipient.styles'
 import { useUserContext } from '@/contexts/UserContext'
 
 const GiftRecipient: React.FC = () => {
-  const { user, isLoggedIn } = useUserContext()
+  const { user } = useUserContext()
 
   return (
     <S.Container>
       <S.PlusButton>＋</S.PlusButton>
-      {isLoggedIn ? (
+      {!!user ? (
         <S.Text>{user?.nickname}님! 선물할 친구를 선택해 주세요.</S.Text>
       ) : (
         <S.Text>선물할 친구를 선택해 주세요.</S.Text>

--- a/src/features/Gift/components/TrendingGiftRanking/TrendingGiftRanking.tsx
+++ b/src/features/Gift/components/TrendingGiftRanking/TrendingGiftRanking.tsx
@@ -4,6 +4,7 @@ import Loading from '@/component/Loading/Loading'
 import * as S from './TrendingGiftRanking.styles'
 import { FilterGender, FilterType } from './TrendingGiftRankingFilter'
 import ProductCard from '@/component/ProductCard/ProductCard'
+import { ROUTE_PATH } from '@/routes/Router'
 import {
   useProductsRanking,
   type Gender,
@@ -37,7 +38,7 @@ const TrendingGiftRanking = () => {
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_COUNT)
   const [isExpanded, setIsExpanded] = useState(false)
 
-  const handleGenderClick = (gender: Gender) => {
+  const handleGenderSelect = (gender: Gender) => {
     const params = new URLSearchParams(searchParams)
     params.set('gender', gender)
     if (selectedType) params.set('type', selectedType)
@@ -53,7 +54,7 @@ const TrendingGiftRanking = () => {
 
   const handleProductSelect = (product: Product) => {
     setSelectedProduct(product)
-    navigate(`/order?productId=${product.id}`)
+    navigate(ROUTE_PATH.ORDER.replace(':productId', String(product.id)))
   }
 
   const handleToggleView = () => {
@@ -90,11 +91,10 @@ const TrendingGiftRanking = () => {
             icon={icon}
             label={label}
             isActive={selectedGender === label}
-            onClick={handleGenderClick}
+            onClick={handleGenderSelect}
           />
         ))}
       </S.GenderTab>
-
       <S.TypeTab>
         {typeList.map((label) => (
           <FilterType
@@ -107,7 +107,7 @@ const TrendingGiftRanking = () => {
       </S.TypeTab>
 
       {loading && <Loading />}
-      {error && <S.ErrorText>에러: {error}</S.ErrorText>}
+      {error && <S.ErrorText>{error}</S.ErrorText>}
 
       {!loading && !error && products.length === 0 && (
         <S.NoProduct>상품이 없습니다.</S.NoProduct>

--- a/src/features/Gift/components/TrendingGiftRanking/TrendingGiftRankingFilter.tsx
+++ b/src/features/Gift/components/TrendingGiftRanking/TrendingGiftRankingFilter.tsx
@@ -4,7 +4,7 @@ import {
   GenderLabel,
   TypeButton,
 } from './TrendingGiftRanking.styles'
-import type { Gender, Type } from './TrendingGiftRanking'
+import type { Gender, Type } from '@/features/Gift/hooks/useProductsRanking'
 
 export const FilterGender: React.FC<{
   icon: string

--- a/src/features/Gift/hooks/useProductsRanking.ts
+++ b/src/features/Gift/hooks/useProductsRanking.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useApi } from '@/hooks/useApi'
 import { api } from '@/lib/axios'
 
 export interface Price {
@@ -38,31 +38,19 @@ const typeMap: Record<Type, string> = {
 }
 
 export const useProductsRanking = (gender: Gender, type: Type) => {
-  const [products, setProducts] = useState<Product[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    const fetchProductsRanking = async () => {
-      setLoading(true)
-      setError(null)
-
-      try {
-        await new Promise((resolve) => setTimeout(resolve, 800))
-        const response = await api.get('/products/ranking', {
-          params: {
-            targetType: genderMap[gender],
-            rankType: typeMap[type],
-          },
-        })
-        setProducts(response.data.data)
-      } catch (err: any) {
-        setError(err.message ?? '에러가 발생하였습니다.')
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchProductsRanking()
+  const { data, loading, error } = useApi<Product[]>(async () => {
+    const res = await api.get('/products/ranking', {
+      params: {
+        targetType: genderMap[gender],
+        rankType: typeMap[type],
+      },
+    })
+    return res.data.data
   }, [gender, type])
-  return { products, loading, error }
+
+  return {
+    products: data ?? [],
+    loading,
+    error,
+  }
 }

--- a/src/features/Gift/hooks/useThemes.ts
+++ b/src/features/Gift/hooks/useThemes.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useApi } from '@/hooks/useApi'
 import { api } from '@/lib/axios'
 
 interface Theme {
@@ -8,27 +8,9 @@ interface Theme {
 }
 
 export const useThemes = () => {
-  const [themes, setThemes] = useState<Theme[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(false)
-
-  useEffect(() => {
-    const fetchThemes = async () => {
-      setLoading(true)
-      setError(false)
-
-      try {
-        await new Promise((resolve) => setTimeout(resolve, 800))
-        const response = await api.get('/themes')
-        setThemes(response.data.data)
-      } catch {
-        setError(true)
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchThemes()
+  const { data, loading, error } = useApi<Theme[]>(async () => {
+    const response = await api.get('/themes')
+    return response.data.data
   }, [])
-
-  return { themes, loading, error }
+  return { themes: data ?? [], loading, error }
 }

--- a/src/features/Login/components/LoginForm.tsx
+++ b/src/features/Login/components/LoginForm.tsx
@@ -1,86 +1,65 @@
 import * as S from './LoginForm.styles'
-import { useNavigate } from 'react-router-dom'
 import KaKaoTitleIcon from '@/assets/icons/kakao-title.svg?react'
 import MyButton from '@/component/Button/Button'
 import { useLoginForm } from '../hooks/useLoginForm'
-import { useUserContext } from '@/contexts/UserContext'
+import { useLoginSubmit } from '../hooks/useLoginSubmit'
 
 interface LoginFormProps {
   redirectPath: string
 }
 
 const LoginForm: React.FC<LoginFormProps> = ({ redirectPath }) => {
+  const methods = useLoginForm()
+  const { submitLogin } = useLoginSubmit(redirectPath)
+
   const {
-    email,
-    setEmail,
-    password,
-    setPassword,
-    emailError,
-    passwordError,
-    checkEmail,
-    checkPassword,
-    loginOK,
-    setEmailTouched,
-    setPasswordTouched,
-  } = useLoginForm()
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = methods
 
-  const { login } = useUserContext()
-  const navigate = useNavigate()
-
-  const handleLoginClick = () => {
-    const emailValid = checkEmail()
-    const passwordValid = checkPassword()
-    if (!emailValid || !passwordValid) return
-
-    const nickname = email.split('@')[0]
-    login({ email, nickname })
-
-    navigate(redirectPath, { replace: true })
-  }
+  const onSubmit = handleSubmit(submitLogin)
 
   return (
     <S.Container>
-      <S.FormContainer>
-        <S.KakaoTitle>
-          <KaKaoTitleIcon />
-        </S.KakaoTitle>
+      <form onSubmit={onSubmit}>
+        <S.FormContainer>
+          <S.KakaoTitle>
+            <KaKaoTitleIcon />
+          </S.KakaoTitle>
 
-        <S.InputForm
-          placeholder="이메일"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          onBlur={() => setEmailTouched(true)}
-          isError={!!emailError}
-        />
-        <S.ErrorMessage isActive={!!emailError}>{emailError}</S.ErrorMessage>
+          <S.InputForm
+            placeholder="이메일"
+            type="email"
+            {...register('email')}
+            isError={!!errors.email}
+          />
+          {errors.email && (
+            <S.ErrorMessage isActive>{errors.email.message}</S.ErrorMessage>
+          )}
 
-        <S.InputForm
-          placeholder="비밀번호"
-          type="password"
-          value={password}
-          onChange={(e) => {
-            setPassword(e.target.value)
-            checkPassword()
-          }}
-          onBlur={() => setPasswordTouched(true)}
-          isError={!!passwordError}
-        />
-        <S.ErrorMessage isActive={!!passwordError}>
-          {passwordError}
-        </S.ErrorMessage>
+          <S.InputForm
+            placeholder="비밀번호"
+            type="password"
+            {...register('password')}
+            isError={!!errors.password}
+          />
+          {errors.password && (
+            <S.ErrorMessage isActive>{errors.password.message}</S.ErrorMessage>
+          )}
 
-        <MyButton
-          onClick={handleLoginClick}
-          variant="primary"
-          size="large"
-          disabled={!loginOK()}
-          fullWidth
-          style={{ marginTop: '32px' }}
-        >
-          로그인
-        </MyButton>
-      </S.FormContainer>
+          <MyButton
+            type="submit"
+            variant="primary"
+            size="large"
+            disabled={!isValid}
+            fullWidth
+            style={{ marginTop: '32px' }}
+          >
+            로그인
+          </MyButton>
+        </S.FormContainer>
+      </form>
     </S.Container>
   )
 }

--- a/src/features/Login/hooks/useLoginForm.ts
+++ b/src/features/Login/hooks/useLoginForm.ts
@@ -1,68 +1,10 @@
-import { useState, useEffect } from 'react'
-const PASSWORD_MIN_LENGTH = 8
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { loginSchema, type LoginFormInputs } from '../schema/loginSchema'
 
 export const useLoginForm = () => {
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [emailError, setEmailError] = useState('')
-  const [passwordError, setPasswordError] = useState('')
-  const [emailTouched, setEmailTouched] = useState(false)
-  const [passwordTouched, setPasswordTouched] = useState(false)
-
-  const emailRegEx =
-    /^[A-Za-z0-9]([-_.]?[A-Za-z0-9])*@[A-Za-z0-9]([-_.]?[A-Za-z0-9])*\.[A-Za-z]{2,3}$/i
-
-  const checkEmail = () => {
-    if (!email) {
-      setEmailError('ID를 입력해주세요.')
-      return false
-    } else if (!emailRegEx.test(email)) {
-      setEmailError('ID는 이메일 형식으로 입력해주세요.')
-      return false
-    }
-    setEmailError('')
-    return true
-  }
-
-  const checkPassword = () => {
-    if (!password) {
-      setPasswordError('비밀번호를 입력해주세요.')
-      return false
-    } else if (password.length < PASSWORD_MIN_LENGTH) {
-      setPasswordError('비밀번호는 8자 이상이어야 합니다.')
-      return false
-    }
-    setPasswordError('')
-    return true
-  }
-
-  useEffect(() => {
-    if (emailTouched) checkEmail()
-  }, [email, emailTouched])
-
-  useEffect(() => {
-    if (passwordTouched) checkPassword()
-  }, [password, passwordTouched])
-
-  const loginOK = () => {
-    return emailRegEx.test(email) && password.length >= PASSWORD_MIN_LENGTH
-  }
-
-  return {
-    email,
-    setEmail,
-    password,
-    setPassword,
-    emailError,
-    setEmailError,
-    passwordError,
-    setPasswordError,
-    checkEmail,
-    checkPassword,
-    loginOK,
-    emailTouched,
-    setEmailTouched,
-    passwordTouched,
-    setPasswordTouched,
-  }
+  return useForm<LoginFormInputs>({
+    resolver: zodResolver(loginSchema),
+    mode: 'onChange',
+  })
 }

--- a/src/features/Login/hooks/useLoginSubmit.ts
+++ b/src/features/Login/hooks/useLoginSubmit.ts
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom'
+import { toast } from 'react-toastify'
+import { useUserContext } from '@/contexts/UserContext'
+import { api } from '@/lib/axios'
+import type { LoginFormInputs } from '../schema/loginSchema'
+
+export const useLoginSubmit = (redirectPath: string) => {
+  const navigate = useNavigate()
+  const { login } = useUserContext()
+
+  const submitLogin = async (data: LoginFormInputs) => {
+    try {
+      const res = await api.post('/login', {
+        email: data.email,
+        password: data.password,
+      })
+
+      const { email, name, authToken } = res.data.data
+      login({ email, nickname: name, authToken })
+      navigate(redirectPath, { replace: true })
+    } catch (err: any) {
+      if (err.response?.status === 400) {
+        toast.error(err.response.data.data.message)
+      } else {
+        toast.error('오류 발생')
+      }
+    }
+  }
+
+  return { submitLogin }
+}

--- a/src/features/Login/schema/loginSchema.ts
+++ b/src/features/Login/schema/loginSchema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'ID를 입력해주세요.')
+    .email('ID는 이메일 형식으로 입력해주세요.'),
+  password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다.'),
+})
+
+export type LoginFormInputs = z.infer<typeof loginSchema>

--- a/src/features/Order/components/ProductInfo/ProductInfo.tsx
+++ b/src/features/Order/components/ProductInfo/ProductInfo.tsx
@@ -1,8 +1,8 @@
 import * as S from './ProductInfo.styles'
-import type { Product } from '@/data/products'
+import type { ProductSummary } from '@/features/Order/hooks/useProductSummary'
 
 interface ProductInfoProps {
-  product: Product
+  product: ProductSummary
 }
 
 const ProductInfo = ({ product }: ProductInfoProps) => {
@@ -13,9 +13,9 @@ const ProductInfo = ({ product }: ProductInfoProps) => {
         <S.ProductImage src={product.imageURL} alt={product.name} />
         <S.ProductDetails>
           <S.ProductName>{product.name}</S.ProductName>
-          <S.BrandName>{product.brandInfo.name}</S.BrandName>
+          <S.BrandName>{product.brandName}</S.BrandName>
           <S.ProductPrice>
-            상품가 {product.price.sellingPrice.toLocaleString()}원
+            상품가 {product.price.toLocaleString()}원
           </S.ProductPrice>
         </S.ProductDetails>
       </S.ProductCard>

--- a/src/features/Order/hooks/useOrderForm.ts
+++ b/src/features/Order/hooks/useOrderForm.ts
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { useNavigate } from 'react-router-dom'
-import { orderSchema } from '../schema/orderSchema'
-import type { Order } from '../schema/orderSchema'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useNavigate } from 'react-router-dom'
+import { orderSchema, type Order } from '../schema/orderSchema'
+import { useOrderSubmit } from '../hooks/useOrderSubmit'
+import { useUserContext } from '@/contexts/UserContext'
+import { ROUTE_PATH } from '@/routes/Router'
 
 interface UseOrderFormParams {
+  productId?: number
   defaultMessage: string
   productName: string
   sellingPrice: number
@@ -14,19 +17,24 @@ interface UseOrderFormParams {
 }
 
 export const useOrderForm = ({
+  productId,
   defaultMessage,
   productName,
   sellingPrice,
   selectedCardId,
   selectedCardMessage,
 }: UseOrderFormParams) => {
+  const { submitOrder } = useOrderSubmit()
   const navigate = useNavigate()
+
+  const { user } = useUserContext()
+  const senderName = user?.nickname
 
   const methods = useForm<Order>({
     resolver: zodResolver(orderSchema),
     defaultValues: {
       message: defaultMessage,
-      sender: '',
+      sender: senderName,
       receivers: [],
     },
     mode: 'onChange',
@@ -37,12 +45,12 @@ export const useOrderForm = ({
     register,
     handleSubmit,
     setValue,
-    trigger,
     getValues,
     formState: { errors },
   } = methods
 
   const [totalPrice, setTotalPrice] = useState(0)
+  const [totalQuantity, setTotalQuantity] = useState(0)
 
   const confirmReceivers = () => {
     const confirmed = getValues('receivers') || []
@@ -50,26 +58,38 @@ export const useOrderForm = ({
       (sum, r) => sum + r.quantity * sellingPrice,
       0
     )
+    const quantity = confirmed.reduce((sum, r) => sum + r.quantity, 0)
     setTotalPrice(price)
+    setTotalQuantity(quantity)
   }
 
   useEffect(() => {
     setValue('message', selectedCardMessage || '')
   }, [selectedCardId, selectedCardMessage, setValue])
 
-  const onSubmit = handleSubmit((data) => {
-    const totalQuantity = data.receivers.reduce(
-      (sum, r) => sum + Number(r.quantity),
-      0
-    )
+  const onSubmit = handleSubmit(async (data) => {
+    const orderPayload = {
+      productId: Number(productId),
+      message: data.message || '',
+      messageCardId: String(selectedCardId),
+      ordererName: data.sender || '',
+      receivers: data.receivers.map((r) => ({
+        name: r.receiver || '',
+        phoneNumber: r.phone || '',
+        quantity: Number(r.quantity) || 1,
+      })),
+    }
 
-    alert(`주문이 완료되었습니다.
+    try {
+      await submitOrder(orderPayload)
+      alert(`주문이 완료되었습니다.
 상품명: ${productName}
 총 수량: ${totalQuantity}
 발신자 이름: ${data.sender}
 메시지: ${data.message}`)
 
-    navigate('/')
+      navigate(ROUTE_PATH.GIFT)
+    } catch {}
   })
 
   return {
@@ -80,7 +100,5 @@ export const useOrderForm = ({
     confirmReceivers,
     totalPrice,
     control,
-    getValues,
-    trigger,
   }
 }

--- a/src/features/Order/hooks/useOrderForm.ts
+++ b/src/features/Order/hooks/useOrderForm.ts
@@ -8,7 +8,7 @@ import { useUserContext } from '@/contexts/UserContext'
 import { ROUTE_PATH } from '@/routes/Router'
 
 interface UseOrderFormParams {
-  productId?: number
+  productId: number
   defaultMessage: string
   productName: string
   sellingPrice: number

--- a/src/features/Order/hooks/useOrderSubmit.ts
+++ b/src/features/Order/hooks/useOrderSubmit.ts
@@ -1,0 +1,32 @@
+import { useNavigate } from 'react-router-dom'
+import { useUserContext } from '@/contexts/UserContext'
+import { api } from '@/lib/axios'
+import { toast } from 'react-toastify'
+import { ROUTE_PATH } from '@/routes/Router'
+
+export const useOrderSubmit = () => {
+  const navigate = useNavigate()
+  const { user } = useUserContext()
+  const authToken = user?.authToken
+
+  const submitOrder = async (orderPayload: any) => {
+    try {
+      const res = await api.post('/order', orderPayload, {
+        headers: { Authorization: authToken },
+      })
+      console.log(res.statusText)
+      return res
+    } catch (error: any) {
+      if (error.response?.status === 401) {
+        toast('로그인이 필요합니다.')
+        navigate(ROUTE_PATH.LOGIN)
+      } else {
+        toast('주문 중 오류가 발생했습니다.')
+        console.error(error.response?.data)
+      }
+      throw error
+    }
+  }
+
+  return { submitOrder }
+}

--- a/src/features/Order/hooks/useProductSummary.ts
+++ b/src/features/Order/hooks/useProductSummary.ts
@@ -1,0 +1,26 @@
+import { useApi } from '@/hooks/useApi'
+import { api } from '@/lib/axios'
+
+export interface ProductSummary {
+  id: number
+  name: string
+  brandName: string
+  price: number
+  imageURL: string
+}
+
+export const useProductSummary = (productId: number | null) => {
+  const { data, loading, error } = useApi<ProductSummary | null>(async () => {
+    if (!productId) {
+      return null
+    }
+    const res = await api.get(`/products/${productId}/summary`)
+    return res.data.data
+  }, [productId])
+
+  return {
+    product: data,
+    loading,
+    error,
+  }
+}

--- a/src/features/Order/pages/OrderPage.tsx
+++ b/src/features/Order/pages/OrderPage.tsx
@@ -1,8 +1,11 @@
-import { useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
-import { useOrderForm } from '../hooks/useOrderForm'
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
 import { FormProvider } from 'react-hook-form'
-
+import { toast } from 'react-toastify'
+import { useOrderForm } from '../hooks/useOrderForm'
+import { useProductSummary } from '../hooks/useProductSummary'
+import { ROUTE_PATH } from '@/routes/Router'
+import { cards } from '@/data/cards'
 import CardSelect from '../components/CardSelect/CardSelect'
 import CardPreview from '../components/CardPreview/CardPreview'
 import MessageInput from '../components/MessageInput/MessageInput'
@@ -10,28 +13,47 @@ import SenderInput from '../components/SenderInput/SenderInput'
 import ProductInfo from '../components/ProductInfo/ProductInfo'
 import BottomPurchaseBar from '../components/BottomPurchaseBar/BottomPurchaseBar'
 import ReceiverSection from '../components/ReceiverSection/ReceiverSection'
-
-import { cards } from '@/data/cards'
-import { products } from '@/data/products'
+import Loading from '@/component/Loading/Loading'
 
 const OrderPage = () => {
-  const [searchParams] = useSearchParams()
-  const productId = searchParams.get('productId')
-  const product = products.find((p) => p.id === Number(productId))
+  const { productId } = useParams<{ productId: string }>()
+  const navigate = useNavigate()
 
-  if (!product) return <div>상품 정보를 찾을 수 없습니다.</div>
+  const idNum = Number(productId)
+  const isInvalidId = !productId || isNaN(idNum)
+
+  const { product, loading, error } = useProductSummary(
+    isInvalidId ? null : idNum
+  )
 
   const [selectedCardId, setSelectedCardId] = useState<number>(904)
   const selectedCard = cards.find((card) => card.id === selectedCardId)!
-  const defaultMessage = selectedCard.defaultTextMessage
 
   const { methods, onSubmit, totalPrice, confirmReceivers } = useOrderForm({
-    defaultMessage,
-    productName: product.name,
-    sellingPrice: product.price.sellingPrice,
+    productId: isInvalidId ? undefined : idNum,
+    defaultMessage: selectedCard.defaultTextMessage,
+    productName: product?.name ?? '',
+    sellingPrice: product?.price ?? 0,
     selectedCardId,
     selectedCardMessage: selectedCard.defaultTextMessage,
   })
+
+  useEffect(() => {
+    if (isInvalidId) {
+      toast.error('잘못된 상품 경로입니다.')
+      navigate(ROUTE_PATH.GIFT, { replace: true })
+    }
+  }, [isInvalidId, navigate])
+
+  useEffect(() => {
+    if (error) {
+      toast.error('상품 정보를 불러오는 데 실패했습니다.')
+      navigate(ROUTE_PATH.GIFT, { replace: true })
+    }
+  }, [error, navigate])
+
+  if (isInvalidId || loading) return <Loading />
+  if (!product) return <div>상품 정보를 찾을 수 없습니다.</div>
 
   return (
     <FormProvider {...methods}>

--- a/src/features/Order/pages/OrderPage.tsx
+++ b/src/features/Order/pages/OrderPage.tsx
@@ -26,31 +26,29 @@ const OrderPage = () => {
     isInvalidId ? null : idNum
   )
 
+  useEffect(() => {
+    if (!isInvalidId) return
+    toast.error('잘못된 상품 경로입니다.')
+    navigate(ROUTE_PATH.GIFT, { replace: true })
+  }, [isInvalidId, navigate])
+
+  useEffect(() => {
+    if (!error) return
+    toast.error('상품 정보를 불러오는 데 실패했습니다.')
+    navigate(ROUTE_PATH.GIFT, { replace: true })
+  }, [error, navigate])
+
   const [selectedCardId, setSelectedCardId] = useState<number>(904)
   const selectedCard = cards.find((card) => card.id === selectedCardId)!
 
   const { methods, onSubmit, totalPrice, confirmReceivers } = useOrderForm({
-    productId: isInvalidId ? undefined : idNum,
+    productId: idNum,
     defaultMessage: selectedCard.defaultTextMessage,
     productName: product?.name ?? '',
     sellingPrice: product?.price ?? 0,
     selectedCardId,
     selectedCardMessage: selectedCard.defaultTextMessage,
   })
-
-  useEffect(() => {
-    if (isInvalidId) {
-      toast.error('잘못된 상품 경로입니다.')
-      navigate(ROUTE_PATH.GIFT, { replace: true })
-    }
-  }, [isInvalidId, navigate])
-
-  useEffect(() => {
-    if (error) {
-      toast.error('상품 정보를 불러오는 데 실패했습니다.')
-      navigate(ROUTE_PATH.GIFT, { replace: true })
-    }
-  }, [error, navigate])
 
   if (isInvalidId || loading) return <Loading />
   if (!product) return <div>상품 정보를 찾을 수 없습니다.</div>

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+
+export const useApi = <T>(
+  fetchFn: () => Promise<T>,
+  dependencies: any[] = []
+) => {
+  const [data, setData] = useState<T | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true)
+      setError('')
+
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 800))
+        const result = await fetchFn()
+        setData(result)
+      } catch (err) {
+        setError(String(err))
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, dependencies)
+
+  return { data, loading, error }
+}

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 export const api = axios.create({
-  baseURL: 'http://localhost:3000/api',
+  baseURL: import.meta.env.VITE_API_URL,
   timeout: 5000,
   headers: {
     'Content-Type': 'application/json',

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,17 +1,18 @@
 import { Navigate, useLocation } from 'react-router-dom'
 import { useUserContext } from '@/contexts/UserContext'
 import type { ReactNode } from 'react'
+import { ROUTE_PATH } from './Router'
 
 interface PrivateRouteProps {
   children: ReactNode
 }
 
 const PrivateRoute = ({ children }: PrivateRouteProps) => {
-  const { isLoggedIn } = useUserContext()
+  const { user } = useUserContext()
   const location = useLocation()
 
-  if (!isLoggedIn) {
-    return <Navigate to="/login" replace state={{ from: location }} />
+  if (!!!user) {
+    return <Navigate to={ROUTE_PATH.LOGIN} replace state={{ from: location }} />
   }
 
   return <>{children}</>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -12,7 +12,7 @@ export const ROUTE_PATH = {
   GIFT: '/',
   LOGIN: '/login',
   MY: '/my',
-  ORDER: '/order',
+  ORDER: '/order/:productId',
   NOT_FOUND: '*',
 }
 
@@ -39,7 +39,7 @@ const Router = createBrowserRouter([
         ),
       },
       {
-        path: ROUTE_PATH.ORDER.slice(1),
+        path: 'order/:productId',
         element: (
           <PrivateRoute>
             <OrderPage />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,4 +11,12 @@ export default defineConfig({
       { find: '@', replacement: '/src' },
     ],
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## ✅ 2단계 - 로그인, 주문하기 API 구현하기

- **로그인 기능**
  - [x] /login api 를 사용하여 로그인 기능 완성하기
  - [x] 로그인 성공 시 내려오는 authToken과 email, name을 userInfo storage에 저장하고 활용하기
  - [x] 4XX 에러가 발생하면 Toast를 통해 에러메시지를 보여주기 (react-toastify 라이브러리 사용)
- **주문하기 기능**
  - [x] /products/:productId/summary api를 사용하여 제품 정보를 가져오기
  - [x] 만약 제품 정보 API에서 4XX 에러가 발생하면 Toast를 통해 에러메시지를 보여주고, 선물하기 홈으로 연결시키기
  - [x] 보내는 사람 Input Field에 userInfo의 name을 defaultValue로 채워놓기
  - [x] /order api를 사용하여 주문하기 기능을 완성하기
  - [x] 주문하기 API의 경우 Authorization헤더에 로그인 응답에서 전달 받은 authToken을 넣어야만 동작하도록 하기
  - [x] 주문하기 API에서 401 에러가 발생하면 로그인 페이지로 연결시키기
  
<br />  

---

<br />

## ✅ step2 1차 PR

**[피드백 반영 사항]**

- 1단계 PR 피드백으로 말씀해주신 **'API를 요청하는 훅을 만들 때 마다 생겨나는 공통 로직'** 에 관한 부분을 고민해보고 **공통 로직 부분을 useApi로 만들어주어 처리해보았습니다.**
- 또한, **필요에 따라 일찍 return하는 걸 고려해보라고 하신 점을 반영해 선물 카테고리 섹션은 따로 return을 추가해주었습니다.**  선물 카테고리 섹션 처럼 에러나 데이터가 없을 때(?) 아예 보이지 않게 처리하는 로직이라 일찍 return을 해도 상관이 없는데, **실시간 급상승 선물 랭킹은 Gender Tap, Type Tap이 에러가 발생하거나 상품이 없어도 UI에 나타나야 해서 기존의 코드를 유지하였습니다.**

**[궁금한 점]**
- **login도 order 처럼 react hook form과 zod를 이용하여 수정해보았습니다.** 요구사항엔 없던 부분이지만, 기능 분리를 위해 진행했는데 **괜찮을까요?** 
- 로그인 기능을 구현하기 위해 필요할 것 같아 위 수정에 맞추어 기능 별 컴포넌트 분리도 진행해보았습니다. 잘 작동하도록 구현하긴 했으나 **login, order 컴포넌트, 기능 분리가 잘 된 건지 궁금합니다.** 폼 관리 - 상태 관리 - api 요청 관리 정도로 분리하였는데 괜찮을까요?
- 주문하기 폼에 접속하려면 애초에 로그인이 되어있어야만 접속할 수 있도록 구현하였기 때문에, 2단계 요구사항 중 '**주문하기 API에서 401 에러가 발생하면 로그인 페이지로 연결시켜요.' 이 부분을 useOrderSubmit에 구현하긴 했으나 잘 작동하는지 확인해보진 못했습니다.** 확인하기 위해선 로그인이 되어있지 않아도 주문하기 폼에 접속이 가능하도록 한 후 테스트를 해봐야할 것 같아요.
- 코드가 점점 복잡해지고 구조도 많아지니 눈에 들어오지 못한 부분들이 많을 것 같습니다. **작성한 질문 외에도 지저분한 부분, 문제가 있는 부분, 개선이 필요한 부분 등이 있다면 알려주시면 감사하겠습니다!**

<br />  

---

<br />

## ✅ step2 2차 PR

**[피드백 반영 사항]**

**1. useOrderForm의 interface UseOrderFormParams 내 productId 앞 `?`를 제거하였습니다
2.  OrderPage 코드를 `early return`을 고려하여 수정하였습니다.**

```
// OrderPage.tsx
const { methods, onSubmit, totalPrice, confirmReceivers } = useOrderForm({
       productId: isInvalidId ? undefined : idNum,
      ... (생략)
```

- 기존에는 OrderPage에서 위처럼 코드를 작성했기 때문에 useOrderForm 에서 productId에 `?` 를 붙여주었습니다. id가 유효한지 아닌지 여부에 따라 유효하지 않다면 undefined를 넘겨주는 구조로 작성했었습니다. 
- ealry return 구조로 변경하고 로직 순서를 변경해줌으로써, 이후 로직은 무조건 유효한 값만 다루게 되는 것이라고 생각되어 기존 코드를 productId: idNum으로 수정하고, useOderForm의 interface 내 productId의 `?`를 제거해주었습니다! 
- 알려주신 코드로 `early return ` 방식으로 수정해보고,  isInvalidId 타입이 어떤 타입으로 바뀌는지 확인해보았습니다. 말씀대로, true로 뜨는 것을 확인했습니다. 

<br />

**3. 지금 처럼 사용하게 되면 T를 무조건 타입을 지정해줘야 하는데, 타입을 명시적으로 지정하지 않고, API의 반환값을 타입으로 쓸 수있는 방법이 있을까요?**
- 이 부분은 충분히 고민하고 수정해본 후 마지막 코드 리뷰 요청 때 반영해서 올려도 될까요? 현재 로컬에서 전체적으로 API 실행이 안된다는 문제점이 있어서 이것을 먼저 해결하는 것이 맞을 것 같아서요!

<br/>

**4. 로컬에서 전체적으로 API가 실행되지 않는 문제점을 해결하기 위해 proxy 설정 및 .env 파일을 추가했습니다.**
-> 사실 문제 해결 방안이 이게 맞는지 잘 모르겠습니다.. ㅠㅠ 
