### PR TITLE
경북대 FE 최지원 - Step3 테마 상품 목록 페이지 구현하기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import Login from "./pages/Login";
 import NotFound from "./pages/NotFound";
 import MyPage from "./pages/MyPage";
 import OrderPage from "@/pages/OrderPage";
-
+import ThemeProduct from "./pages/ThemeProduct";
 const App = () => {
   return (
     <ThemeProvider theme={theme}>
@@ -30,6 +30,7 @@ const App = () => {
             />
             <Route path="*" element={<NotFound />} />
             <Route path="/order/:id" element={<RequireAuth><OrderPage /></RequireAuth>} />
+            <Route path="/theme/:id" element={<ThemeProduct />} />
           </Routes>
         </AuthProvider>
       </BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { GlobalResetStyle } from "./styles/reset";
-import { Global } from "@emotion/react";
-import { ThemeProvider } from "@emotion/react";
+import { Global, ThemeProvider } from "@emotion/react";
 import { theme } from "./styles/theme/theme";
 import { AuthProvider } from "./contexts/AuthContext";
 import RequireAuth from "./components/auth/RequireAuth";
@@ -9,8 +8,10 @@ import GiftMain from "./pages/GiftMain";
 import Login from "./pages/Login";
 import NotFound from "./pages/NotFound";
 import MyPage from "./pages/MyPage";
-import OrderPage from "@/pages/OrderPage";
+import OrderPage from "./pages/OrderPage";
 import ThemeProduct from "./pages/ThemeProduct";
+import { PATH } from "@/constants/path";
+
 const App = () => {
   return (
     <ThemeProvider theme={theme}>
@@ -18,19 +19,27 @@ const App = () => {
       <BrowserRouter>
         <AuthProvider>
           <Routes>
-            <Route path="/" element={<GiftMain />} />
-            <Route path="/login" element={<Login />} />
+            <Route path={PATH.HOME} element={<GiftMain />} />
+            <Route path={PATH.LOGIN} element={<Login />} />
             <Route
-              path="/my"
+              path={PATH.MY_PAGE}
               element={
                 <RequireAuth>
                   <MyPage />
                 </RequireAuth>
               }
             />
-            <Route path="*" element={<NotFound />} />
-            <Route path="/order/:id" element={<RequireAuth><OrderPage /></RequireAuth>} />
-            <Route path="/theme/:id" element={<ThemeProduct />} />
+            <Route
+              path={PATH.ORDER()}
+              element={
+                <RequireAuth>
+                  <OrderPage />
+                </RequireAuth>
+              }
+            />
+            <Route path={PATH.THEME()} element={<ThemeProduct />} />
+            <Route path={PATH.NOT_FOUND} element={<NotFound />} />
+            <Route path={PATH.ALL} element={<NotFound />} />
           </Routes>
         </AuthProvider>
       </BrowserRouter>

--- a/src/api/orderapi.ts
+++ b/src/api/orderapi.ts
@@ -11,8 +11,8 @@ export const postCreateOrder = async (
     {
       productId,
       message: form.message,
-      senderName: form.senderName,
-      selectedCardId: form.selectedCardId,
+      ordererName: form.senderName,
+      messageCardId: String(form.selectedCardId),
       receivers: form.receivers.map((r) => ({
         name: r.name,
         phoneNumber: r.phone,
@@ -21,9 +21,8 @@ export const postCreateOrder = async (
     },
     {
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: token,
       },
     }
   );
 };
-

--- a/src/api/theme.ts
+++ b/src/api/theme.ts
@@ -1,5 +1,6 @@
 //테마 목록 조회용
 import { client } from "./client";
+import type { ProductSummary } from "@/api/product";
 
 export interface Theme {
   themeId: number;
@@ -30,5 +31,20 @@ export const fetchThemeInfo = async (
   const response = await client.get<{ data: ThemeInfo }>(
     `/api/themes/${themeId}/info`
   );
+  return response.data.data;
+};
+
+export const fetchThemeProducts = async (
+  themeId: number,
+  cursor: number = 0,
+  limit: number = 15
+): Promise<{
+  list: ProductSummary[];
+  cursor: number;
+  hasMoreList: boolean;
+}> => {
+  const response = await client.get(`/api/themes/${themeId}/products`, {
+    params: { cursor, limit },
+  });
   return response.data.data;
 };

--- a/src/api/theme.ts
+++ b/src/api/theme.ts
@@ -6,6 +6,13 @@ export interface Theme {
   name: string;
   image: string;
 }
+export interface ThemeInfo {
+  themeId: number;
+  name: string;
+  title: string;
+  description: string;
+  backgroundColor: string;
+}
 
 interface FetchThemesResponse {
   data: Theme[];
@@ -14,5 +21,14 @@ interface FetchThemesResponse {
 
 export const fetchThemes = async (): Promise<Theme[]> => {
   const response = await client.get<FetchThemesResponse>("/api/themes");
+  return response.data.data;
+};
+
+export const fetchThemeInfo = async (
+  themeId: number
+): Promise<ThemeInfo> => {
+  const response = await client.get<{ data: ThemeInfo }>(
+    `/api/themes/${themeId}/info`
+  );
   return response.data.data;
 };

--- a/src/components/category/CategoryCard.tsx
+++ b/src/components/category/CategoryCard.tsx
@@ -1,10 +1,30 @@
 /** @jsxImportSource @emotion/react */
 import styled from '@emotion/styled';
+import { useNavigate } from "react-router-dom";
 
 type Props={
     name: string;
     image: string;
+    themeId: number;
 };
+
+
+export const CategoryCard = ({ themeId, name, image }: Props) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(`/theme/${themeId}`);
+  };
+
+  return (
+    <Card onClick={handleClick}>
+      <Image src={image} alt={name} />
+      <Label>{name}</Label>
+    </Card>
+  );
+};
+
+
 const Card = styled.div`
     display: flex;
     flex-direction: column;
@@ -24,12 +44,3 @@ const Label = styled.p`
   color: ${({ theme }) => theme.colors.textDefault};
   text-align: center;
 `;
-
-export const CategoryCard = ({ name, image }: Props)=>{
-    return (
-    <Card>
-      <Image src={image} alt={name} />
-      <Label>{name}</Label>
-    </Card>
-  );
-}

--- a/src/components/category/CategoryCard.tsx
+++ b/src/components/category/CategoryCard.tsx
@@ -1,19 +1,19 @@
 /** @jsxImportSource @emotion/react */
-import styled from '@emotion/styled';
+import styled from "@emotion/styled";
 import { useNavigate } from "react-router-dom";
+import { PATH } from "@/constants/path";
 
-type Props={
-    name: string;
-    image: string;
-    themeId: number;
+type Props = {
+  name: string;
+  image: string;
+  themeId: number;
 };
-
 
 export const CategoryCard = ({ themeId, name, image }: Props) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(`/theme/${themeId}`);
+    navigate(PATH.THEME(themeId));
   };
 
   return (
@@ -24,14 +24,12 @@ export const CategoryCard = ({ themeId, name, image }: Props) => {
   );
 };
 
-
 const Card = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    cursor: pointer;
-
-`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+`;
 const Image = styled.img`
   width: 72px;
   height: 72px;

--- a/src/components/category/CategorySection.tsx
+++ b/src/components/category/CategorySection.tsx
@@ -30,9 +30,8 @@ export const CategorySection = () => {
   }, [fetchThemesData]);
 
   if (loading) {
-  return <Spinner size={48} withWrapper />;
-}
-
+    return <Spinner size={48} withWrapper />;
+  }
 
   if (error || themes.length === 0) {
     return <ErrorBanner>해당 ID에 일치하는 데이터가 없습니다.</ErrorBanner>;
@@ -41,12 +40,16 @@ export const CategorySection = () => {
   return (
     <CategoryGrid>
       {themes.map(({ themeId, name, image }) => (
-        <CategoryCard key={themeId} name={name} image={image} />
+        <CategoryCard
+          key={themeId}
+          themeId={themeId}
+          name={name}
+          image={image}
+        />
       ))}
     </CategoryGrid>
   );
 };
-
 
 const CategoryGrid = styled.section`
   width: 100%;

--- a/src/components/order/MessageCardSection.tsx
+++ b/src/components/order/MessageCardSection.tsx
@@ -13,14 +13,15 @@ const MessageCardSection = () => {
   const message = useWatch({ control, name: "message" });
 
   useEffect(() => {
-    if (!message?.trim() && selectedCardId) {
-      const defaultCard = messageCards.find(
-        card => String(card.id) === selectedCardId,
-      );
-      if (defaultCard) {
-        setValue("message", defaultCard.defaultTextMessage);
-      }
-    }
+    if (message?.trim() || !selectedCardId) return;
+
+    const defaultCard = messageCards.find(
+      card => String(card.id) === selectedCardId,
+    );
+
+    if (!defaultCard) return;
+
+    setValue("message", defaultCard.defaultTextMessage);
   }, [message, selectedCardId, setValue]);
 
   const handleSelectCard = (card: MessageCard) => {

--- a/src/components/order/MessageCardSection.tsx
+++ b/src/components/order/MessageCardSection.tsx
@@ -12,7 +12,7 @@ const MessageCardSection = () => {
   const message = useWatch({ control, name: "message" });
 
   const handleSelectCard = (card: MessageCard) => {
-    setValue("selectedCardId", card.id);
+setValue("selectedCardId", String(card.id));
 
     const isCurrentMessageDefault = messageCards.some(
       (c) => c.defaultTextMessage === message
@@ -24,8 +24,7 @@ const MessageCardSection = () => {
   };
 
   const selectedCard =
-    messageCards.find((card) => card.id === selectedCardId) ?? messageCards[0];
-
+  messageCards.find((card) => String(card.id) === selectedCardId) ?? messageCards[0];
   return (
     <Wrapper>
       <ThumbList>

--- a/src/components/order/MessageCardSection.tsx
+++ b/src/components/order/MessageCardSection.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource @emotion/react */
+import { useEffect } from "react";
 import styled from "@emotion/styled";
 import { useFormContext, useWatch } from "react-hook-form";
 import { messageCards } from "@/mock/messageCards";
@@ -11,11 +12,22 @@ const MessageCardSection = () => {
   const selectedCardId = useWatch({ control, name: "selectedCardId" });
   const message = useWatch({ control, name: "message" });
 
+  useEffect(() => {
+    if (!message?.trim() && selectedCardId) {
+      const defaultCard = messageCards.find(
+        card => String(card.id) === selectedCardId,
+      );
+      if (defaultCard) {
+        setValue("message", defaultCard.defaultTextMessage);
+      }
+    }
+  }, [message, selectedCardId, setValue]);
+
   const handleSelectCard = (card: MessageCard) => {
-setValue("selectedCardId", String(card.id));
+    setValue("selectedCardId", String(card.id));
 
     const isCurrentMessageDefault = messageCards.some(
-      (c) => c.defaultTextMessage === message
+      c => c.defaultTextMessage === message,
     );
 
     if (isCurrentMessageDefault || !message?.trim()) {
@@ -24,11 +36,12 @@ setValue("selectedCardId", String(card.id));
   };
 
   const selectedCard =
-  messageCards.find((card) => String(card.id) === selectedCardId) ?? messageCards[0];
+    messageCards.find(card => String(card.id) === selectedCardId) ??
+    messageCards[0];
   return (
     <Wrapper>
       <ThumbList>
-        {messageCards.map((card) => (
+        {messageCards.map(card => (
           <ThumbButton
             key={card.id}
             onClick={() => handleSelectCard(card)}

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -3,5 +3,7 @@ export const PATH = {
   LOGIN: "/login",
   MY_PAGE: "/my",
   ORDER: (id: string | number = ":id") => `/order/${id}`,
+  THEME: (id: string | number = ":id") => `/theme/${id}`,
   NOT_FOUND: "/not-found",
+  ALL: "*",
 } as const;

--- a/src/hooks/useIntersect.ts
+++ b/src/hooks/useIntersect.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useCallback } from "react";
+
+type Callback = () => void;
+
+interface UseIntersectOptions {
+  rootMargin?: string;
+  threshold?: number;
+}
+
+export const useIntersect = <T extends Element = HTMLDivElement>(
+  onIntersect: Callback,
+  canObserve: boolean,
+  options: UseIntersectOptions = { rootMargin: "0px", threshold: 1.0 }
+) => {
+  const ref = useRef<T | null>(null);
+
+  const observerCallback = useCallback(
+    ([entry]: IntersectionObserverEntry[]) => {
+      if (entry.isIntersecting) {
+        onIntersect();
+      }
+    },
+    [onIntersect]
+  );
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || !canObserve) return;
+
+    const observer = new IntersectionObserver(observerCallback, options);
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [observerCallback, canObserve, options]);
+
+  return ref;
+};

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -43,7 +43,7 @@ const OrderPage = () => {
     defaultValues: {
       senderName: user?.email.split("@")[0] ?? "",
       message: "",
-      selectedCardId: null,
+      selectedCardId: "904",
       receivers: [],
     },
     mode: "onBlur",
@@ -60,24 +60,36 @@ const OrderPage = () => {
   };
 
   const onValid = async (data: OrderFormValues) => {
-    if (!product) return;
+  if (!product) return;
 
-    if (!token) {
-      toast.error("로그인이 필요합니다.");
-      navigate(PATH.LOGIN, { replace: true }); 
-      return;
-    }
+  if (!token) {
+    toast.error("로그인이 필요합니다.");
+    navigate(PATH.LOGIN, { replace: true });
+    return;
+  }
 
-    try {
-      await postCreateOrder(data, product.id, token);
-      toast.success("주문이 성공적으로 완료되었습니다!");
-      navigate(PATH.HOME, { replace: true }); 
-    } catch (err: any) {
-      const msg =
-        err?.response?.data?.data?.message || "주문 요청 중 오류가 발생했습니다.";
-      toast.error(msg);
+  try {
+    await postCreateOrder(data, product.id, token);
+
+    const totalQuantity = data.receivers.reduce((sum, r) => sum + r.quantity, 0);
+
+    const confirmed = window.confirm(
+      `주문이 완료되었습니다.\n` +
+      `상품명: ${product.name}\n` +
+      `구매 수량: ${totalQuantity}\n` +
+      `받는 사람: ${data.receivers[0].name}\n` +
+      `메시지: ${data.message}`
+    );
+
+    if (confirmed) {
+      navigate(PATH.HOME, { replace: true });
     }
-  };
+  } catch (err: any) {
+    const msg = err?.response?.data?.data?.message || "주문 요청 중 오류가 발생했습니다.";
+    toast.error(msg);
+  }
+};
+
 
   const fetchProduct = useCallback(async () => {
     if (!id || isNaN(Number(id))) {

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -22,7 +22,8 @@ import { getProductSummary } from "@/api/product";
 import type { ProductSummary } from "@/api/product";
 import { postCreateOrder } from "@/api/orderapi";
 import { useAuth } from "@/contexts/AuthContext";
-import { PATH } from "@/constants/path"; 
+import { PATH } from "@/constants/path";
+import { messageCards } from "@/mock/messageCards";
 
 const OrderPage = () => {
   const navigate = useNavigate();
@@ -48,11 +49,21 @@ const OrderPage = () => {
     },
     mode: "onBlur",
   });
-
+  useEffect(() => {
+    const defaultCard = messageCards.find(
+      c => c.id === Number(methods.getValues("selectedCardId")),
+    );
+    if (defaultCard) {
+      methods.setValue("message", defaultCard.defaultTextMessage);
+    }
+  }, [methods]);
   const { handleSubmit, watch, setValue } = methods;
   const receivers = watch("receivers") ?? [];
 
-  const totalQuantity = receivers.reduce((sum, r) => sum + (r.quantity ?? 0), 0);
+  const totalQuantity = receivers.reduce(
+    (sum, r) => sum + (r.quantity ?? 0),
+    0,
+  );
   const totalAmount = (product?.price.sellingPrice ?? 0) * totalQuantity;
 
   const onReceiverComplete = (data: OrderFormValues["receivers"]) => {
@@ -60,36 +71,25 @@ const OrderPage = () => {
   };
 
   const onValid = async (data: OrderFormValues) => {
-  if (!product) return;
+    if (!product) return;
 
-  if (!token) {
-    toast.error("로그인이 필요합니다.");
-    navigate(PATH.LOGIN, { replace: true });
-    return;
-  }
-
-  try {
-    await postCreateOrder(data, product.id, token);
-
-    const totalQuantity = data.receivers.reduce((sum, r) => sum + r.quantity, 0);
-
-    const confirmed = window.confirm(
-      `주문이 완료되었습니다.\n` +
-      `상품명: ${product.name}\n` +
-      `구매 수량: ${totalQuantity}\n` +
-      `받는 사람: ${data.receivers[0].name}\n` +
-      `메시지: ${data.message}`
-    );
-
-    if (confirmed) {
-      navigate(PATH.HOME, { replace: true });
+    if (!token) {
+      toast.error("로그인이 필요합니다.");
+      navigate(PATH.LOGIN, { replace: true });
+      return;
     }
-  } catch (err: any) {
-    const msg = err?.response?.data?.data?.message || "주문 요청 중 오류가 발생했습니다.";
-    toast.error(msg);
-  }
-};
 
+    try {
+      await postCreateOrder(data, product.id, token);
+      toast.success("주문이 성공적으로 완료되었습니다!");
+      navigate(PATH.HOME, { replace: true });
+    } catch (err: any) {
+      const msg =
+        err?.response?.data?.data?.message ||
+        "주문 요청 중 오류가 발생했습니다.";
+      toast.error(msg);
+    }
+  };
 
   const fetchProduct = useCallback(async () => {
     if (!id || isNaN(Number(id))) {
@@ -103,9 +103,10 @@ const OrderPage = () => {
       setProduct(data);
     } catch (err: any) {
       const msg =
-        err?.response?.data?.data?.message || "상품 정보를 불러오지 못했습니다.";
+        err?.response?.data?.data?.message ||
+        "상품 정보를 불러오지 못했습니다.";
       toast.error(msg);
-      navigate(PATH.NOT_FOUND, { replace: true }); 
+      navigate(PATH.NOT_FOUND, { replace: true });
     }
   }, [id, navigate]);
 

--- a/src/pages/ThemeProduct.tsx
+++ b/src/pages/ThemeProduct.tsx
@@ -8,6 +8,8 @@ import { Navigation } from "@/components/header/Navigation";
 import { Spinner } from "@/components/common/Spinner";
 import { fetchThemeInfo, fetchThemeProducts } from "@/api/theme";
 import { PATH } from "@/constants/path";
+import { useIntersect } from "@/hooks/useIntersect";
+import type { ProductSummary } from "@/api/product";
 
 interface ThemeInfo {
   themeId: number;
@@ -17,29 +19,16 @@ interface ThemeInfo {
   backgroundColor: string;
 }
 
-interface Product {
-  id: number;
-  name: string;
-  price: {
-    basicPrice: number;
-    sellingPrice: number;
-    discountRate: number;
-  };
-  imageURL: string;
-  brandInfo: {
-    id: number;
-    name: string;
-    imageURL: string;
-  };
-}
-
 const ThemeProduct = () => {
   const { id } = useParams();
   const navigate = useNavigate();
 
   const [theme, setTheme] = useState<ThemeInfo | null>(null);
-  const [products, setProducts] = useState<Product[]>([]);
+  const [products, setProducts] = useState<ProductSummary[]>([]);
+  const [cursor, setCursor] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
   const [loading, setLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   const loadThemeInfo = useCallback(async () => {
     try {
@@ -53,20 +42,35 @@ const ThemeProduct = () => {
   }, [id, navigate]);
 
   const loadProducts = useCallback(async () => {
+    if (!hasMore || isLoadingMore) return;
+
+    setIsLoadingMore(true);
     try {
-      const data = await fetchThemeProducts(Number(id), 0, 10);
-      setProducts(data.list);
+      const data = await fetchThemeProducts(Number(id), cursor, 10);
+      setProducts(prev => [...prev, ...data.list]);
+      setCursor(data.cursor);
+      setHasMore(data.hasMoreList);
     } catch {
-      setProducts([]);
+      setHasMore(false);
     } finally {
+      setIsLoadingMore(false);
       setLoading(false);
     }
-  }, [id]);
+  }, [cursor, hasMore, isLoadingMore, id]);
 
   useEffect(() => {
     loadThemeInfo();
+  }, [loadThemeInfo]);
+
+  useEffect(() => {
     loadProducts();
-  }, [loadThemeInfo, loadProducts]);
+  }, [loadProducts]);
+
+  const observerRef = useIntersect<HTMLDivElement>(() => {
+  if (!isLoadingMore && hasMore) {
+    loadProducts();
+  }
+}, hasMore);
 
   if (loading) return <Spinner size={48} withWrapper />;
 
@@ -88,16 +92,32 @@ const ThemeProduct = () => {
             <EmptyBox>상품이 없습니다.</EmptyBox>
           ) : (
             <ProductList>
-              {products.map((item) => (
-                <ProductCard key={item.id}>
-                  <ProductImage src={item.imageURL} alt={item.name} />
-                  <ProductName>{item.name}</ProductName>
-                  <ProductBrand>{item.brandInfo.name}</ProductBrand>
-                  <ProductPrice>
-                    {item.price.sellingPrice.toLocaleString()}원
-                  </ProductPrice>
-                </ProductCard>
-              ))}
+              {products.map((item, index) => {
+                const isLast = index === products.length - 1;
+                return (
+                  <ProductCard key={item.id}>
+                    {isLast ? (
+                      <div ref={observerRef}>
+                        <ProductImage src={item.imageURL} alt={item.name} />
+                        <ProductName>{item.name}</ProductName>
+                        <ProductBrand>{item.brandInfo.name}</ProductBrand>
+                        <ProductPrice>
+                          {item.price.sellingPrice.toLocaleString()}원
+                        </ProductPrice>
+                      </div>
+                    ) : (
+                      <>
+                        <ProductImage src={item.imageURL} alt={item.name} />
+                        <ProductName>{item.name}</ProductName>
+                        <ProductBrand>{item.brandInfo.name}</ProductBrand>
+                        <ProductPrice>
+                          {item.price.sellingPrice.toLocaleString()}원
+                        </ProductPrice>
+                      </>
+                    )}
+                  </ProductCard>
+                );
+              })}
             </ProductList>
           )}
         </Section>

--- a/src/pages/ThemeProduct.tsx
+++ b/src/pages/ThemeProduct.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import styled from "@emotion/styled";
+import * as S from "@/styles/ThemeProductStyles";
 
 import { PageLayout } from "@/components/layout/PageLayout";
 import { PageContainer } from "@/components/layout/PageContainer";
@@ -54,23 +54,18 @@ const ThemeProduct = () => {
       setHasMore(false);
     } finally {
       setIsLoadingMore(false);
-      setLoading(false);
     }
   }, [cursor, hasMore, isLoadingMore, id]);
 
   useEffect(() => {
-    loadThemeInfo();
-  }, [loadThemeInfo]);
+    const init = async () => {
+      await Promise.all([loadThemeInfo(), loadProducts()]);
+      setLoading(false);
+    };
+    init();
+  }, [loadThemeInfo, loadProducts]);
 
-  useEffect(() => {
-    loadProducts();
-  }, [loadProducts]);
-
-  const observerRef = useIntersect<HTMLDivElement>(() => {
-    if (!isLoadingMore && hasMore) {
-      loadProducts();
-    }
-  }, hasMore);
+  const observerRef = useIntersect<HTMLDivElement>(loadProducts, hasMore);
 
   if (loading) return <Spinner size={48} withWrapper />;
 
@@ -80,121 +75,51 @@ const ThemeProduct = () => {
         <Navigation />
 
         {theme && (
-          <HeroSection bgColor={theme.backgroundColor}>
-            <ThemeLabel>{theme.name}</ThemeLabel>
-            <ThemeTitle>{theme.title}</ThemeTitle>
-            <ThemeDescription>{theme.description}</ThemeDescription>
-          </HeroSection>
+          <S.HeroSection bgColor={theme.backgroundColor}>
+            <S.ThemeLabel>{theme.name}</S.ThemeLabel>
+            <S.ThemeTitle>{theme.title}</S.ThemeTitle>
+            <S.ThemeDescription>{theme.description}</S.ThemeDescription>
+          </S.HeroSection>
         )}
 
-        <Section>
+        <S.Section>
           {products.length === 0 ? (
-            <EmptyBox>상품이 없습니다.</EmptyBox>
+            <S.EmptyBox>상품이 없습니다.</S.EmptyBox>
           ) : (
-            <ProductList>
+            <S.ProductList>
               {products.map((item, index) => {
                 const isLast = index === products.length - 1;
                 return (
-                  <ProductCard key={item.id}>
+                  <S.ProductCard key={item.id}>
                     {isLast ? (
                       <div ref={observerRef}>
-                        <ProductImage src={item.imageURL} alt={item.name} />
-                        <ProductName>{item.name}</ProductName>
-                        <ProductBrand>{item.brandInfo.name}</ProductBrand>
-                        <ProductPrice>
+                        <S.ProductImage src={item.imageURL} alt={item.name} />
+                        <S.ProductName>{item.name}</S.ProductName>
+                        <S.ProductBrand>{item.brandInfo.name}</S.ProductBrand>
+                        <S.ProductPrice>
                           {item.price.sellingPrice.toLocaleString()}원
-                        </ProductPrice>
+                        </S.ProductPrice>
                       </div>
                     ) : (
                       <>
-                        <ProductImage src={item.imageURL} alt={item.name} />
-                        <ProductName>{item.name}</ProductName>
-                        <ProductBrand>{item.brandInfo.name}</ProductBrand>
-                        <ProductPrice>
+                        <S.ProductImage src={item.imageURL} alt={item.name} />
+                        <S.ProductName>{item.name}</S.ProductName>
+                        <S.ProductBrand>{item.brandInfo.name}</S.ProductBrand>
+                        <S.ProductPrice>
                           {item.price.sellingPrice.toLocaleString()}원
-                        </ProductPrice>
+                        </S.ProductPrice>
                       </>
                     )}
-                  </ProductCard>
+                  </S.ProductCard>
                 );
               })}
-            </ProductList>
+            </S.ProductList>
           )}
           {hasMore && isLoadingMore && <Spinner size={32} withWrapper />}
-        </Section>
+        </S.Section>
       </PageContainer>
     </PageLayout>
   );
 };
 
 export default ThemeProduct;
-
-const HeroSection = styled.section<{ bgColor: string }>`
-  background-color: ${({ bgColor }) => bgColor};
-  padding: 24px 16px;
-  border-radius: 5px;
-`;
-
-const ThemeLabel = styled.p`
-  ${({ theme }) => theme.typography.label1Regular};
-  color: ${({ theme }) => theme.colors.gray00};
-  margin-bottom: 8px;
-`;
-
-const ThemeTitle = styled.h2`
-  ${({ theme }) => theme.typography.title1Bold};
-  color: ${({ theme }) => theme.colors.gray00};
-  margin: 0 0 5px;
-`;
-
-const ThemeDescription = styled.p`
-  ${({ theme }) => theme.typography.body1Regular};
-  color: ${({ theme }) => theme.colors.gray00};
-  margin: 0;
-`;
-
-const Section = styled.section`
-  margin-top: 5px;
-`;
-
-const EmptyBox = styled.div`
-  text-align: center;
-  padding: 40px 0;
-  color: ${({ theme }) => theme.colors.gray800};
-  ${({ theme }) => theme.typography.body1Regular};
-`;
-
-const ProductList = styled.ul`
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 5px;
-`;
-
-const ProductCard = styled.li`
-  border-radius: 5px;
-  padding: 15px;
-`;
-
-const ProductImage = styled.img`
-  width: 100%;
-  height: auto;
-  border-radius: 8px;
-`;
-
-const ProductName = styled.p`
-  ${({ theme }) => theme.typography.body2Bold};
-  color: ${({ theme }) => theme.colors.textDefault};
-  margin: 9px 0 4px;
-`;
-
-const ProductBrand = styled.p`
-  ${({ theme }) => theme.typography.body2Regular};
-  color: ${({ theme }) => theme.colors.textSub};
-  margin: 0;
-`;
-
-const ProductPrice = styled.p`
-  ${({ theme }) => theme.typography.body1Bold};
-  color: ${({ theme }) => theme.colors.textDefault};
-  margin: 3px 0 0;
-`;

--- a/src/pages/ThemeProduct.tsx
+++ b/src/pages/ThemeProduct.tsx
@@ -1,0 +1,22 @@
+import { useParams } from "react-router-dom";
+import { PageLayout } from "@/components/layout/PageLayout";
+import { PageContainer } from "@/components/layout/PageContainer";
+import { Navigation } from "@/components/header/Navigation";
+
+const ThemeProduct = () => {
+  const { id } = useParams();
+
+  return (
+    <PageLayout>
+      <PageContainer>
+        <Navigation />
+        <main>
+          <h2>테마 상품 페이지</h2>
+          <p>theme Id: {id}</p>
+        </main>
+      </PageContainer>
+    </PageLayout>
+  );
+};
+
+export default ThemeProduct;

--- a/src/pages/ThemeProduct.tsx
+++ b/src/pages/ThemeProduct.tsx
@@ -6,9 +6,8 @@ import { PageLayout } from "@/components/layout/PageLayout";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { Navigation } from "@/components/header/Navigation";
 import { Spinner } from "@/components/common/Spinner";
-import { fetchThemeInfo } from "@/api/theme"; 
+import { fetchThemeInfo, fetchThemeProducts } from "@/api/theme";
 import { PATH } from "@/constants/path";
-
 
 interface ThemeInfo {
   themeId: number;
@@ -18,11 +17,28 @@ interface ThemeInfo {
   backgroundColor: string;
 }
 
-const ThemeProductsPage = () => {
+interface Product {
+  id: number;
+  name: string;
+  price: {
+    basicPrice: number;
+    sellingPrice: number;
+    discountRate: number;
+  };
+  imageURL: string;
+  brandInfo: {
+    id: number;
+    name: string;
+    imageURL: string;
+  };
+}
+
+const ThemeProduct = () => {
   const { id } = useParams();
   const navigate = useNavigate();
 
   const [theme, setTheme] = useState<ThemeInfo | null>(null);
+  const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
 
   const loadThemeInfo = useCallback(async () => {
@@ -33,22 +49,32 @@ const ThemeProductsPage = () => {
       if (err?.response?.status === 404) {
         navigate(PATH.HOME, { replace: true });
       }
-    } finally {
-      setLoading(false);
     }
   }, [id, navigate]);
 
+  const loadProducts = useCallback(async () => {
+    try {
+      const data = await fetchThemeProducts(Number(id), 0, 10);
+      setProducts(data.list);
+    } catch {
+      setProducts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
   useEffect(() => {
     loadThemeInfo();
-  }, [loadThemeInfo]);
+    loadProducts();
+  }, [loadThemeInfo, loadProducts]);
 
-  if (loading) 
-    return <Spinner size={48} withWrapper />;
+  if (loading) return <Spinner size={48} withWrapper />;
 
   return (
     <PageLayout>
       <PageContainer>
         <Navigation />
+
         {theme && (
           <HeroSection bgColor={theme.backgroundColor}>
             <ThemeLabel>{theme.name}</ThemeLabel>
@@ -56,23 +82,42 @@ const ThemeProductsPage = () => {
             <ThemeDescription>{theme.description}</ThemeDescription>
           </HeroSection>
         )}
+
+        <Section>
+          {products.length === 0 ? (
+            <EmptyBox>상품이 없습니다.</EmptyBox>
+          ) : (
+            <ProductList>
+              {products.map((item) => (
+                <ProductCard key={item.id}>
+                  <ProductImage src={item.imageURL} alt={item.name} />
+                  <ProductName>{item.name}</ProductName>
+                  <ProductBrand>{item.brandInfo.name}</ProductBrand>
+                  <ProductPrice>
+                    {item.price.sellingPrice.toLocaleString()}원
+                  </ProductPrice>
+                </ProductCard>
+              ))}
+            </ProductList>
+          )}
+        </Section>
       </PageContainer>
     </PageLayout>
   );
 };
 
-export default ThemeProductsPage;
+export default ThemeProduct;
 
 const HeroSection = styled.section<{ bgColor: string }>`
   background-color: ${({ bgColor }) => bgColor};
-  padding: 25px 20px;
-  border-radius: 8px;
+  padding: 24px 16px;
+  border-radius: 5px;
 `;
 
 const ThemeLabel = styled.p`
   ${({ theme }) => theme.typography.label1Regular};
   color: ${({ theme }) => theme.colors.textDefault};
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 `;
 
 const ThemeTitle = styled.h2`
@@ -85,4 +130,50 @@ const ThemeDescription = styled.p`
   ${({ theme }) => theme.typography.body1Regular};
   color: ${({ theme }) => theme.colors.textDefault};
   margin: 0;
+`;
+
+const Section = styled.section`
+  margin-top: 5px;
+`;
+
+const EmptyBox = styled.div`
+  text-align: center;
+  padding: 40px 0;
+  color: ${({ theme }) => theme.colors.textSub};
+  ${({ theme }) => theme.typography.body1Regular};
+`;
+
+const ProductList = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 5px;
+`;
+
+const ProductCard = styled.li`
+  border-radius: 5px;
+  padding: 15px;
+`;
+
+const ProductImage = styled.img`
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+`;
+
+const ProductName = styled.p`
+  ${({ theme }) => theme.typography.body2Bold};
+  color: ${({ theme }) => theme.colors.textDefault};
+  margin: 9px 0 4px;
+`;
+
+const ProductBrand = styled.p`
+  ${({ theme }) => theme.typography.body2Regular};
+  color: ${({ theme }) => theme.colors.textSub};
+  margin: 0;
+`;
+
+const ProductPrice = styled.p`
+  ${({ theme }) => theme.typography.body1Bold};
+  color: ${({ theme }) => theme.colors.textDefault};
+  margin: 3px 0 0;
 `;

--- a/src/pages/ThemeProduct.tsx
+++ b/src/pages/ThemeProduct.tsx
@@ -136,19 +136,19 @@ const HeroSection = styled.section<{ bgColor: string }>`
 
 const ThemeLabel = styled.p`
   ${({ theme }) => theme.typography.label1Regular};
-  color: ${({ theme }) => theme.colors.textDefault};
+  color: ${({ theme }) => theme.colors.gray00};
   margin-bottom: 8px;
 `;
 
 const ThemeTitle = styled.h2`
   ${({ theme }) => theme.typography.title1Bold};
-  color: ${({ theme }) => theme.colors.textDefault};
+  color: ${({ theme }) => theme.colors.gray00};
   margin: 0 0 5px;
 `;
 
 const ThemeDescription = styled.p`
   ${({ theme }) => theme.typography.body1Regular};
-  color: ${({ theme }) => theme.colors.textDefault};
+  color: ${({ theme }) => theme.colors.gray00};
   margin: 0;
 `;
 
@@ -159,7 +159,7 @@ const Section = styled.section`
 const EmptyBox = styled.div`
   text-align: center;
   padding: 40px 0;
-  color: ${({ theme }) => theme.colors.textSub};
+  color: ${({ theme }) => theme.colors.gray800};
   ${({ theme }) => theme.typography.body1Regular};
 `;
 

--- a/src/pages/ThemeProduct.tsx
+++ b/src/pages/ThemeProduct.tsx
@@ -1,22 +1,88 @@
-import { useParams } from "react-router-dom";
+import { useEffect, useState, useCallback } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import styled from "@emotion/styled";
+
 import { PageLayout } from "@/components/layout/PageLayout";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { Navigation } from "@/components/header/Navigation";
+import { Spinner } from "@/components/common/Spinner";
+import { fetchThemeInfo } from "@/api/theme"; 
+import { PATH } from "@/constants/path";
 
-const ThemeProduct = () => {
+
+interface ThemeInfo {
+  themeId: number;
+  name: string;
+  title: string;
+  description: string;
+  backgroundColor: string;
+}
+
+const ThemeProductsPage = () => {
   const { id } = useParams();
+  const navigate = useNavigate();
+
+  const [theme, setTheme] = useState<ThemeInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadThemeInfo = useCallback(async () => {
+    try {
+      const data = await fetchThemeInfo(Number(id));
+      setTheme(data);
+    } catch (err: any) {
+      if (err?.response?.status === 404) {
+        navigate(PATH.HOME, { replace: true });
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [id, navigate]);
+
+  useEffect(() => {
+    loadThemeInfo();
+  }, [loadThemeInfo]);
+
+  if (loading) 
+    return <Spinner size={48} withWrapper />;
 
   return (
     <PageLayout>
       <PageContainer>
         <Navigation />
-        <main>
-          <h2>테마 상품 페이지</h2>
-          <p>theme Id: {id}</p>
-        </main>
+        {theme && (
+          <HeroSection bgColor={theme.backgroundColor}>
+            <ThemeLabel>{theme.name}</ThemeLabel>
+            <ThemeTitle>{theme.title}</ThemeTitle>
+            <ThemeDescription>{theme.description}</ThemeDescription>
+          </HeroSection>
+        )}
       </PageContainer>
     </PageLayout>
   );
 };
 
-export default ThemeProduct;
+export default ThemeProductsPage;
+
+const HeroSection = styled.section<{ bgColor: string }>`
+  background-color: ${({ bgColor }) => bgColor};
+  padding: 25px 20px;
+  border-radius: 8px;
+`;
+
+const ThemeLabel = styled.p`
+  ${({ theme }) => theme.typography.label1Regular};
+  color: ${({ theme }) => theme.colors.textDefault};
+  margin-bottom: 10px;
+`;
+
+const ThemeTitle = styled.h2`
+  ${({ theme }) => theme.typography.title1Bold};
+  color: ${({ theme }) => theme.colors.textDefault};
+  margin: 0 0 5px;
+`;
+
+const ThemeDescription = styled.p`
+  ${({ theme }) => theme.typography.body1Regular};
+  color: ${({ theme }) => theme.colors.textDefault};
+  margin: 0;
+`;

--- a/src/pages/ThemeProduct.tsx
+++ b/src/pages/ThemeProduct.tsx
@@ -67,10 +67,10 @@ const ThemeProduct = () => {
   }, [loadProducts]);
 
   const observerRef = useIntersect<HTMLDivElement>(() => {
-  if (!isLoadingMore && hasMore) {
-    loadProducts();
-  }
-}, hasMore);
+    if (!isLoadingMore && hasMore) {
+      loadProducts();
+    }
+  }, hasMore);
 
   if (loading) return <Spinner size={48} withWrapper />;
 
@@ -120,6 +120,7 @@ const ThemeProduct = () => {
               })}
             </ProductList>
           )}
+          {hasMore && isLoadingMore && <Spinner size={32} withWrapper />}
         </Section>
       </PageContainer>
     </PageLayout>

--- a/src/styles/ThemeProductStyles.ts
+++ b/src/styles/ThemeProductStyles.ts
@@ -1,0 +1,71 @@
+import styled from "@emotion/styled";
+
+export const HeroSection = styled.section<{ bgColor: string }>`
+  background-color: ${({ bgColor }) => bgColor};
+  padding: 24px 16px;
+  border-radius: 5px;
+`;
+
+export const ThemeLabel = styled.p`
+  ${({ theme }) => theme.typography.label1Regular};
+  color: ${({ theme }) => theme.colors.gray00};
+  margin-bottom: 8px;
+`;
+
+export const ThemeTitle = styled.h2`
+  ${({ theme }) => theme.typography.title1Bold};
+  color: ${({ theme }) => theme.colors.gray00};
+  margin: 0 0 5px;
+`;
+
+export const ThemeDescription = styled.p`
+  ${({ theme }) => theme.typography.body1Regular};
+  color: ${({ theme }) => theme.colors.gray00};
+  margin: 0;
+`;
+
+export const Section = styled.section`
+  margin-top: 5px;
+`;
+
+export const EmptyBox = styled.div`
+  text-align: center;
+  padding: 40px 0;
+  color: ${({ theme }) => theme.colors.gray800};
+  ${({ theme }) => theme.typography.body1Regular};
+`;
+
+export const ProductList = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 5px;
+`;
+
+export const ProductCard = styled.li`
+  border-radius: 5px;
+  padding: 15px;
+`;
+
+export const ProductImage = styled.img`
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+`;
+
+export const ProductName = styled.p`
+  ${({ theme }) => theme.typography.body2Bold};
+  color: ${({ theme }) => theme.colors.textDefault};
+  margin: 9px 0 4px;
+`;
+
+export const ProductBrand = styled.p`
+  ${({ theme }) => theme.typography.body2Regular};
+  color: ${({ theme }) => theme.colors.textSub};
+  margin: 0;
+`;
+
+export const ProductPrice = styled.p`
+  ${({ theme }) => theme.typography.body1Bold};
+  color: ${({ theme }) => theme.colors.textDefault};
+  margin: 3px 0 0;
+`;

--- a/src/validations/orderSchema.ts
+++ b/src/validations/orderSchema.ts
@@ -11,7 +11,7 @@ export const orderFormSchema = z.object({
     .min(1, "메시지를 입력해주세요."),
 
   selectedCardId: z
-    .number()
+    .string()
     .nullable()
     .optional(),
 


### PR DESCRIPTION
안녕하세요 멘토님!  
경북대 FE 최지원입니다!!

이번 PR에서는 주어진 Step3 과제 요구사항에 따라 **테마 상품 목록 페이지 구현**을 중심으로 작업을 진행하였고,  
이전에 작업했던 기능 중 **메시지 카드 선택 로직 개선**, **주문 요청 오류 수정** 등 발견된 문제들을 함께 개선했습니다.

---

##  테마 상품 목록 페이지 구현
- `/api/themes/:themeId/info` API를 호출하여 테마의 히어로 영역을 구현했습니다.
  - API 호출 실패 시 (404), `navigate(PATH.HOME)`를 통해 홈으로 리디렉트되도록 처리했습니다.
- `/api/themes/:themeId/products` API를 활용하여 테마에 해당하는 상품 리스트를 구현했습니다.
  - Intersection Observer API를 사용해 무한 스크롤 방식으로 데이터를 로드합니다.
  - 상품 리스트가 비어 있을 경우에는 `EmptyProductList` 컴포넌트를 렌더링하여 안내 UI를 제공했습니다.

---

## 메시지 카드 선택 로직 개선
- 메시지 카드 선택 시, 해당 카드의 `defaultTextMessage`가 자동으로 입력되도록 처리했습니다.
- 페이지 진입 시에도 기본 메시지 카드(904)의 메시지가 자동으로 입력되도록 `useEffect`를 활용해 초기화했습니다.

## 주문 요청 오류 수정 및 안정성 개선
- `/api/order` 요청 시 `messageCardId`가 숫자 타입으로 전달되어 string 타입과 불일치 문제가 발생했던 오류를 `String(form.selectedCardId)`로 해결했습니다.
- Authorization 토큰이 누락되거나 유효하지 않을 경우, `401` 에러 발생 시 `toast`로 안내 후 `/login` 페이지로 리디렉트 처리했습니다.

---

##  UX 향상을 위한 추가 개선
- 참고 자료에서 브랜드명을 두 번 표시했던 부분을 개선하여, **상품명**을 강조하고 **브랜드명은 한 번만** 노출되도록 변경했습니다.
- 사용자 입장에서 같은 브랜드의 다양한 메뉴를 탐색하기 쉽도록 정보를 재배치하여 가독성과 사용성을 높였습니다.

---

 과제 가이드에 맞춰  
- 기능 단위로 커밋을 분리하였고,  
- 일관된 스타일과 재사용 가능한 컴포넌트 구조를 유지하기 위해 노력했습니다.

감사합니다!  
리뷰 잘 부탁드립니다 🙇‍♀️
