### PR TITLE
충남대 FE 신재호 3단계 - 테마 상품 목록 페이지 구현하기

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -43,3 +43,4 @@ export { default as ReceiverForm } from './organisms/ReceiverForm';
 export { default as ReceiverModal } from './organisms/ReceiverModal';
 export { default as ReceiverSection } from './organisms/ReceiverSection';
 export { default as SenderSection } from './organisms/SenderSection';
+export { default as ThemeHeroSection } from './organisms/ThemeHeroSection';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -44,3 +44,4 @@ export { default as ReceiverModal } from './organisms/ReceiverModal';
 export { default as ReceiverSection } from './organisms/ReceiverSection';
 export { default as SenderSection } from './organisms/SenderSection';
 export { default as ThemeHeroSection } from './organisms/ThemeHeroSection';
+export { default as ThemeProductSection } from './organisms/ThemeProductSection';

--- a/src/components/molecules/CategoryField/index.tsx
+++ b/src/components/molecules/CategoryField/index.tsx
@@ -37,6 +37,7 @@ const CategoryField = () => {
           {fetchState.data.map((theme) => (
             <CategoryItemCard
               key={theme.themeId}
+              themeId={theme.themeId}
               imageUrl={theme.image}
               title={theme.name}
             />

--- a/src/components/molecules/CategoryItemCard/index.tsx
+++ b/src/components/molecules/CategoryItemCard/index.tsx
@@ -1,15 +1,22 @@
+import { useNavigate } from 'react-router-dom';
 import * as S from './styles';
 
 interface ItemCardProps {
+  themeId: number;
   imageUrl: string;
   title: string;
 }
 
 const ItemCard = (props: ItemCardProps) => {
-  const { imageUrl, title } = props;
+  const { themeId, imageUrl, title } = props;
+  const navigate = useNavigate();
+  
+  const handleClick = () => {
+    navigate(`/themes/${themeId}`);
+  };
   
   return (
-    <S.Card>
+    <S.Card onClick={handleClick}>
       <S.Image src={imageUrl} alt={title} />
       <S.Title>{title}</S.Title>
     </S.Card>

--- a/src/components/molecules/RankingItemCard/index.tsx
+++ b/src/components/molecules/RankingItemCard/index.tsx
@@ -15,7 +15,7 @@ const RankingItemCard = (props: RankingItemCardProps) => {
   
   return (
     <S.Card onClick={onClick}>
-      {rank && <S.RankBadge rank={rank}>{rank}</S.RankBadge>}
+      {rank != null && <S.RankBadge rank={rank}>{rank}</S.RankBadge>}
       <S.Image src={imageUrl} alt={title} />
       <S.Subtitle>{subtitle}</S.Subtitle>
       <S.ProductName>{title}</S.ProductName>

--- a/src/components/molecules/RankingItemCard/index.tsx
+++ b/src/components/molecules/RankingItemCard/index.tsx
@@ -6,7 +6,7 @@ interface RankingItemCardProps {
   title: string;
   subtitle?: string;
   price?: number;
-  rank: number;
+  rank?: number;
   onClick?: ClickHandler;
 }
 
@@ -15,7 +15,7 @@ const RankingItemCard = (props: RankingItemCardProps) => {
   
   return (
     <S.Card onClick={onClick}>
-      <S.RankBadge rank={rank}>{rank}</S.RankBadge>
+      {rank && <S.RankBadge rank={rank}>{rank}</S.RankBadge>}
       <S.Image src={imageUrl} alt={title} />
       <S.Subtitle>{subtitle}</S.Subtitle>
       <S.ProductName>{title}</S.ProductName>

--- a/src/components/organisms/ThemeHeroSection/index.tsx
+++ b/src/components/organisms/ThemeHeroSection/index.tsx
@@ -42,15 +42,19 @@ const ThemeHeroSection = ({ themeId }: ThemeHeroSectionProps) => {
 
   return (
     <>
-      {fetchState.isLoading ? (
+      {fetchState.isLoading && (
         <S.ThemeHeroContainer>
           <Loading height="80px" message="테마 정보를 불러오는 중..." />
         </S.ThemeHeroContainer>
-      ) : fetchState.isError || !fetchState.data ? (
+      )}
+
+      {fetchState.isError && (
         <S.ThemeHeroContainer>
           <ErrorMessage height="80px" />
         </S.ThemeHeroContainer>
-      ) : (
+      )}
+
+      {!fetchState.isLoading && !fetchState.isError && fetchState.data && (
         <S.ThemeHeroContainer backgroundColor={fetchState.data.backgroundColor}>    
           <S.ThemeName>{fetchState.data.name}</S.ThemeName>
           <S.ThemeTitle>{fetchState.data.title}</S.ThemeTitle>

--- a/src/components/organisms/ThemeHeroSection/index.tsx
+++ b/src/components/organisms/ThemeHeroSection/index.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { getThemeInfo } from '@/lib/api/themes';
 import type { ThemeInfo } from '@/types/api';
 import { useFetchState } from '@/hooks/useFetchState';
+import { useErrorHandler } from '@/utils/errorHandler';
 import { Loading, ErrorMessage } from '@/components';
 import * as S from './styles';
 
@@ -10,6 +12,8 @@ interface ThemeHeroSectionProps {
 }
 
 const ThemeHeroSection = ({ themeId }: ThemeHeroSectionProps) => {
+  const navigate = useNavigate();
+  const { handleError } = useErrorHandler();
   const { fetchState, setLoading, setSuccess, setError, reset } = useFetchState<ThemeInfo | null>(null);
 
   useEffect(() => {
@@ -24,13 +28,17 @@ const ThemeHeroSection = ({ themeId }: ThemeHeroSectionProps) => {
         const themeInfo = await getThemeInfo(themeId);
         setSuccess(themeInfo);
       } catch (error) {
-        console.error('테마 정보 조회 실패:', error);
+        handleError(error, {
+          404: () => {
+            navigate('/');
+          }
+        });    
         setError();
       }
     };
 
     fetchThemeInfo();
-  }, [themeId, setLoading, setSuccess, setError, reset]);
+  }, [themeId, setLoading, setSuccess, setError, reset, handleError, navigate]);
 
   return (
     <>

--- a/src/components/organisms/ThemeHeroSection/index.tsx
+++ b/src/components/organisms/ThemeHeroSection/index.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import { getThemeInfo } from '@/lib/api/themes';
+import type { ThemeInfo } from '@/types/api';
+import { useFetchState } from '@/hooks/useFetchState';
+import { Loading, ErrorMessage } from '@/components';
+import * as S from './styles';
+
+interface ThemeHeroSectionProps {
+  themeId?: number;
+}
+
+const ThemeHeroSection = ({ themeId }: ThemeHeroSectionProps) => {
+  const { fetchState, setLoading, setSuccess, setError, reset } = useFetchState<ThemeInfo | null>(null);
+
+  useEffect(() => {
+    if (!themeId) {
+      reset();
+      return;
+    }
+
+    const fetchThemeInfo = async () => {
+      setLoading(true);
+      try {
+        const themeInfo = await getThemeInfo(themeId);
+        setSuccess(themeInfo);
+      } catch (error) {
+        console.error('테마 정보 조회 실패:', error);
+        setError();
+      }
+    };
+
+    fetchThemeInfo();
+  }, [themeId, setLoading, setSuccess, setError, reset]);
+
+  return (
+    <>
+      {fetchState.isLoading ? (
+        <S.ThemeHeroContainer>
+          <Loading height="80px" message="테마 정보를 불러오는 중..." />
+        </S.ThemeHeroContainer>
+      ) : fetchState.isError || !fetchState.data ? (
+        <S.ThemeHeroContainer>
+          <ErrorMessage height="80px" />
+        </S.ThemeHeroContainer>
+      ) : (
+        <S.ThemeHeroContainer backgroundColor={fetchState.data.backgroundColor}>    
+          <S.ThemeName>{fetchState.data.name}</S.ThemeName>
+          <S.ThemeTitle>{fetchState.data.title}</S.ThemeTitle>
+          <S.ThemeDescription>{fetchState.data.description}</S.ThemeDescription>
+        </S.ThemeHeroContainer>
+      )}
+    </>
+  );
+};
+
+export default ThemeHeroSection;

--- a/src/components/organisms/ThemeHeroSection/styles.ts
+++ b/src/components/organisms/ThemeHeroSection/styles.ts
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+
+export const ThemeHeroContainer = styled.section<{ backgroundColor?: string }>`
+  background-color: ${({ backgroundColor }) => backgroundColor || '#6366f1'};
+  padding: ${({ theme }) => `${theme.spacing.spacing6} ${theme.spacing.spacing4}`};
+  color: white;
+  position: relative;
+`;
+
+export const ThemeName = styled.p`
+  ${({ theme }) => theme.typography.label1Bold};
+  margin: 0 0 ${({ theme }) => theme.spacing.spacing2} 0;
+`;
+
+export const ThemeTitle = styled.h5`
+  ${({ theme }) => theme.typography.title1Bold};
+  margin-bottom: ${({ theme }) => theme.spacing.spacing1};
+`;
+
+export const ThemeDescription = styled.p`
+  ${({ theme }) => theme.typography.subtitle1Regular};
+`;

--- a/src/components/organisms/ThemeProductSection/index.tsx
+++ b/src/components/organisms/ThemeProductSection/index.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useThemeProducts } from '@/hooks/useThemeProducts';
 import { RankingItemCard, Loading } from '@/components';
 import type { RankingProduct } from '@/types/api';
 import * as S from './styles';
@@ -10,7 +10,7 @@ interface ThemeProductSectionProps {
 
 const ThemeProductSection = ({ themeId }: ThemeProductSectionProps) => {
   const navigate = useNavigate();
-  const { products, isLoading, hasMore, loadingRef } = useInfiniteScroll({ themeId });
+  const { products, isLoading, hasMore, loadingRef } = useThemeProducts(themeId);
 
   const handleProductClick = (product: RankingProduct) => {
     navigate(`/order/${product.id}`);

--- a/src/components/organisms/ThemeProductSection/index.tsx
+++ b/src/components/organisms/ThemeProductSection/index.tsx
@@ -1,0 +1,61 @@
+import { useNavigate } from 'react-router-dom';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { RankingItemCard, Loading } from '@/components';
+import type { RankingProduct } from '@/types/api';
+import * as S from './styles';
+
+interface ThemeProductSectionProps {
+  themeId: number;
+}
+
+const ThemeProductSection = ({ themeId }: ThemeProductSectionProps) => {
+  const navigate = useNavigate();
+  const { products, isLoading, hasMore, loadingRef } = useInfiniteScroll({ themeId });
+
+  const handleProductClick = (product: RankingProduct) => {
+    navigate(`/order/${product.id}`);
+  };
+
+  if (isLoading && products.length === 0) {
+    return (
+      <S.Section>
+        <Loading height="400px" />
+      </S.Section>
+    );
+  }
+
+  if (!isLoading && products.length === 0) {
+    return (
+      <S.Section>
+        <S.EmptyMessage>해당 테마의 상품이 없습니다.</S.EmptyMessage>
+      </S.Section>
+    );
+  }
+
+  return (
+    <S.Section>
+      <S.Grid>
+        {products.map((product) => (
+          <RankingItemCard
+            key={product.id}
+            imageUrl={product.imageURL}
+            title={product.name}
+            subtitle={product.brandInfo.name}
+            price={product.price.sellingPrice}
+            onClick={() => handleProductClick(product)}
+          />
+        ))}
+      </S.Grid>
+
+      <div ref={loadingRef} style={{ height: '20px' }}>
+        {hasMore && isLoading && (
+          <S.LoadingMore>
+            <Loading height="60px" message="상품을 불러오는 중..." />
+          </S.LoadingMore>
+        )}
+      </div>
+    </S.Section>
+  );
+};
+
+export default ThemeProductSection; 

--- a/src/components/organisms/ThemeProductSection/styles.ts
+++ b/src/components/organisms/ThemeProductSection/styles.ts
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+
+export const Section = styled.section`
+  padding: ${({ theme }) => `${theme.spacing.spacing6} ${theme.spacing.spacing4}`};
+`;
+
+export const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: ${({ theme }) => theme.spacing.spacing3};
+  margin-bottom: ${({ theme }) => theme.spacing.spacing4};
+  width: 100%;
+`;
+
+export const EmptyMessage = styled.div`
+  text-align: center;
+  padding: ${({ theme }) => `${theme.spacing.spacing12} ${theme.spacing.spacing4}`};
+  ${({ theme }) => theme.typography.body1Regular}
+  color: ${({ theme }) => theme.semantic.text.sub};
+`;
+
+export const LoadingMore = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: ${({ theme }) => theme.spacing.spacing6};
+`; 

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -19,16 +19,23 @@ export const useInfiniteScroll = <T>({
   const [isLoading, setIsLoading] = useState(true);
   const loadingRef = useRef<HTMLDivElement>(null);
 
-  const loadMore = useCallback(async () => {
-    if (isLoading || !hasMore) return;
+  const loadData = useCallback(async (type: 'initial' | 'more') => {
+    if (type === 'more' && (isLoading || !hasMore)) return;  
     setIsLoading(true);
     
     try {
-      const response = await fetcher(cursor);
-      setItems(prev => [...prev, ...response.list]);
+      const targetCursor = type === 'initial' ? 0 : cursor;
+      const response = await fetcher(targetCursor);
+
+      if (type === 'initial') {
+        setItems(response.list);
+      } else {
+        setItems(prev => [...prev, ...response.list]);
+      }    
       setCursor(response.nextCursor);
       setHasMore(response.hasMore);
     } catch (error) {
+      if (type === 'initial') setItems([]);
       setHasMore(false);
     } finally {
       setIsLoading(false);
@@ -41,7 +48,7 @@ export const useInfiniteScroll = <T>({
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
-          loadMore();
+          loadData('more');
         }
       },
       { threshold: 1.0 }
@@ -49,28 +56,14 @@ export const useInfiniteScroll = <T>({
 
     observer.observe(loadingRef.current);
     return () => observer.disconnect();
-  }, [loadMore]);
+  }, [loadData]);
 
   useEffect(() => {
-    const loadInitial = async () => {
-      setItems([]);
-      setCursor(0);
-      setHasMore(true);
-      setIsLoading(true);
-      try {
-        const response = await fetcher(0);
-        setItems(response.list);
-        setCursor(response.nextCursor);
-        setHasMore(response.hasMore);
-      } catch (error) {
-        setItems([]);
-        setHasMore(false);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    loadInitial();
+    setItems([]);
+    setCursor(0);
+    setHasMore(true);
+    setIsLoading(true);
+    loadData('initial');
   }, [fetcher]);
 
   return {

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,75 +1,69 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { getThemeProducts } from '@/lib/api/themes';
-import type { RankingProduct } from '@/types/api';
 
-interface UseInfiniteScrollOptions {
-  themeId: number;
-  limit?: number;
-}
-
-interface UseInfiniteScrollReturn {
-  products: RankingProduct[];
-  isLoading: boolean;
+interface FetchResult<T> {
+  list: T[];
+  nextCursor?: number | null;
   hasMore: boolean;
-  loadingRef: React.RefObject<HTMLDivElement | null>;
 }
 
-export const useInfiniteScroll = ({ 
-  themeId, 
-  limit = 20 
-}: UseInfiniteScrollOptions): UseInfiniteScrollReturn => {
-  const [products, setProducts] = useState<RankingProduct[]>([]);
-  const [cursor, setCursor] = useState(0);
+interface UseInfiniteScrollOptions<T> {
+  fetcher: (cursor?: number | null) => Promise<FetchResult<T>>;
+}
+
+export const useInfiniteScroll = <T>({ 
+  fetcher,
+}: UseInfiniteScrollOptions<T>) => {
+  const [items, setItems] = useState<T[]>([]);
+  const [cursor, setCursor] = useState<number | null | undefined>(0);
   const [hasMore, setHasMore] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
   const loadingRef = useRef<HTMLDivElement>(null);
 
   const loadMore = useCallback(async () => {
+    if (isLoading || !hasMore) return;
     setIsLoading(true);
     
     try {
-      const response = await getThemeProducts(themeId, cursor, limit);
-      setProducts(prev => [...prev, ...response.list]);
-      setCursor(response.cursor);
-      setHasMore(response.hasMoreList);
+      const response = await fetcher(cursor);
+      setItems(prev => [...prev, ...response.list]);
+      setCursor(response.nextCursor);
+      setHasMore(response.hasMore);
     } catch (error) {
       setHasMore(false);
     } finally {
       setIsLoading(false);
     }
-  }, [themeId, cursor, limit]);
+  }, [fetcher, cursor, hasMore, isLoading]);
 
   useEffect(() => {
+    if (!loadingRef.current) return;
+
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting && hasMore && !isLoading) {
+        if (entry.isIntersecting) {
           loadMore();
         }
       },
       { threshold: 1.0 }
     );
 
-    const element = loadingRef.current;
-    if (element) observer.observe(element);
-
-    return () => {
-      if (element) observer.unobserve(element);
-    };
-  }, [loadMore, hasMore, isLoading]);
+    observer.observe(loadingRef.current);
+    return () => observer.disconnect();
+  }, [loadMore]);
 
   useEffect(() => {
     const loadInitial = async () => {
-      setProducts([]);
+      setItems([]);
       setCursor(0);
       setHasMore(true);
       setIsLoading(true);
       try {
-        const response = await getThemeProducts(themeId, 0, limit);
-        setProducts(response.list);
-        setCursor(response.cursor);
-        setHasMore(response.hasMoreList);
+        const response = await fetcher(0);
+        setItems(response.list);
+        setCursor(response.nextCursor);
+        setHasMore(response.hasMore);
       } catch (error) {
-        setProducts([]);
+        setItems([]);
         setHasMore(false);
       } finally {
         setIsLoading(false);
@@ -77,10 +71,10 @@ export const useInfiniteScroll = ({
     };
 
     loadInitial();
-  }, [themeId, limit]);
+  }, [fetcher]);
 
   return {
-    products,
+    items,
     isLoading,
     hasMore,
     loadingRef,

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,88 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { getThemeProducts } from '@/lib/api/themes';
+import type { RankingProduct } from '@/types/api';
+
+interface UseInfiniteScrollOptions {
+  themeId: number;
+  limit?: number;
+}
+
+interface UseInfiniteScrollReturn {
+  products: RankingProduct[];
+  isLoading: boolean;
+  hasMore: boolean;
+  loadingRef: React.RefObject<HTMLDivElement | null>;
+}
+
+export const useInfiniteScroll = ({ 
+  themeId, 
+  limit = 20 
+}: UseInfiniteScrollOptions): UseInfiniteScrollReturn => {
+  const [products, setProducts] = useState<RankingProduct[]>([]);
+  const [cursor, setCursor] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const loadingRef = useRef<HTMLDivElement>(null);
+
+  const loadMore = useCallback(async () => {
+    setIsLoading(true);
+    
+    try {
+      const response = await getThemeProducts(themeId, cursor, limit);
+      setProducts(prev => [...prev, ...response.list]);
+      setCursor(response.cursor);
+      setHasMore(response.hasMoreList);
+    } catch (error) {
+      setHasMore(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [themeId, cursor, limit]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && hasMore && !isLoading) {
+          loadMore();
+        }
+      },
+      { threshold: 1.0 }
+    );
+
+    const element = loadingRef.current;
+    if (element) observer.observe(element);
+
+    return () => {
+      if (element) observer.unobserve(element);
+    };
+  }, [loadMore, hasMore, isLoading]);
+
+  useEffect(() => {
+    const loadInitial = async () => {
+      setProducts([]);
+      setCursor(0);
+      setHasMore(true);
+      setIsLoading(true);
+      try {
+        const response = await getThemeProducts(themeId, 0, limit);
+        setProducts(response.list);
+        setCursor(response.cursor);
+        setHasMore(response.hasMoreList);
+      } catch (error) {
+        setProducts([]);
+        setHasMore(false);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadInitial();
+  }, [themeId, limit]);
+
+  return {
+    products,
+    isLoading,
+    hasMore,
+    loadingRef,
+  };
+}; 

--- a/src/hooks/useThemeProducts.ts
+++ b/src/hooks/useThemeProducts.ts
@@ -1,0 +1,25 @@
+import { getThemeProducts } from '@/lib/api/themes';
+import type { RankingProduct } from '@/types/api';
+import { useInfiniteScroll } from './useInfiniteScroll'; 
+import { useCallback } from 'react';
+
+export const useThemeProducts = (themeId: number, limit: number = 20) => {
+  const fetchThemeProducts = useCallback(async (cursor: number | null = 0) => {
+    const response = await getThemeProducts(themeId, cursor ?? 0, limit);
+
+    return {
+      list: response.list,
+      nextCursor: response.cursor,
+      hasMore: response.hasMoreList,
+    };
+  }, [themeId, limit]);
+
+  const { 
+    items: products,
+    isLoading, 
+    hasMore, 
+    loadingRef 
+  } = useInfiniteScroll<RankingProduct>({ fetcher: fetchThemeProducts });
+
+  return { products, isLoading, hasMore, loadingRef };
+};

--- a/src/lib/api/themes.ts
+++ b/src/lib/api/themes.ts
@@ -1,7 +1,12 @@
 import { api } from "./core";
-import { type Theme } from "../../types/api";
+import type { Theme, ThemeInfo } from "../../types/api";
 
 export const getThemes = async (): Promise<Theme[]> => {
     const response = await api.get<{data: Theme[]}>("/themes");
+    return response.data.data;
+}
+
+export const getThemeInfo = async (themeId: number): Promise<ThemeInfo> => {
+    const response = await api.get<{data: ThemeInfo}>(`/themes/${themeId}/info`);
     return response.data.data;
 }

--- a/src/lib/api/themes.ts
+++ b/src/lib/api/themes.ts
@@ -1,5 +1,5 @@
 import { api } from "./core";
-import type { Theme, ThemeInfo } from "../../types/api";
+import type { Theme, ThemeInfo, ThemeProductsResponse } from "../../types/api";
 
 export const getThemes = async (): Promise<Theme[]> => {
     const response = await api.get<{data: Theme[]}>("/themes");
@@ -8,5 +8,17 @@ export const getThemes = async (): Promise<Theme[]> => {
 
 export const getThemeInfo = async (themeId: number): Promise<ThemeInfo> => {
     const response = await api.get<{data: ThemeInfo}>(`/themes/${themeId}/info`);
+    return response.data.data;
+}
+
+export const getThemeProducts = async (
+    themeId: number,
+    cursor = 0,
+    limit = 10
+): Promise<ThemeProductsResponse> => {
+    const response = await api.get<{data: ThemeProductsResponse}>(
+        `/themes/${themeId}/products`,
+        { params: { cursor, limit } }
+    );
     return response.data.data;
 }

--- a/src/pages/Theme/index.tsx
+++ b/src/pages/Theme/index.tsx
@@ -1,0 +1,16 @@
+import { useParams } from 'react-router-dom';
+import { ThemeHeroSection } from '@/components';
+import * as S from './styles';
+
+const Theme = () => {
+  const { themeId } = useParams<{ themeId: string }>();
+  const numericThemeId = themeId ? parseInt(themeId, 10) : undefined;
+
+  return (
+    <S.Container>
+      <ThemeHeroSection themeId={numericThemeId} />
+    </S.Container>
+  );
+};
+
+export default Theme; 

--- a/src/pages/Theme/index.tsx
+++ b/src/pages/Theme/index.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { ThemeHeroSection } from '@/components';
+import { ThemeHeroSection, ThemeProductSection } from '@/components';
 import * as S from './styles';
 
 const Theme = () => {
@@ -9,6 +9,7 @@ const Theme = () => {
   return (
     <S.Container>
       <ThemeHeroSection themeId={numericThemeId} />
+      {numericThemeId && <ThemeProductSection themeId={numericThemeId} />}
     </S.Container>
   );
 };

--- a/src/pages/Theme/styles.ts
+++ b/src/pages/Theme/styles.ts
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  min-height: 100vh;
+  width: 100%;
+`; 

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -3,3 +3,4 @@ export { default as Login } from './Login';
 export { default as MyPage } from './MyPage';
 export { default as NotFound } from './NotFound';
 export { default as Order } from './Order';
+export { default as Theme } from './Theme';

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter} from 'react-router-dom';
 import Layout from '../layout';
 import ProtectedRoute from './ProtectedRoute';
-import { Home, Login, MyPage, Order, NotFound } from '@/pages';
+import { Home, Login, MyPage, Order, NotFound, Theme } from '@/pages';
 
 const router = createBrowserRouter([
   {
@@ -15,6 +15,10 @@ const router = createBrowserRouter([
       {
         path: 'login',
         element: <Login />,
+      },
+      {
+        path: 'themes/:themeId',
+        element: <Theme />,
       },
       {
         path: 'mypage',

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -4,6 +4,14 @@ export interface Theme {
     image: string,
 }
 
+export interface ThemeInfo {
+    themeId: number;
+    name: string;
+    title: string;
+    description: string;
+    backgroundColor: string;
+}
+
 export interface RankingProduct {
     id: number;
     name: string;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -12,6 +12,12 @@ export interface ThemeInfo {
     backgroundColor: string;
 }
 
+export interface ThemeProductsResponse {
+    list: RankingProduct[];
+    cursor: number;
+    hasMoreList: boolean;
+}
+
 export interface RankingProduct {
     id: number;
     name: string;


### PR DESCRIPTION
step3 작업사항입니다!
- 목표 : 홈에서 테마 카드클릭시 테마 페이지로 이어지게하고, themes/Info, themes/products API를 구현하여 페이지를 구성
- 구현내용 :
1. 먼저 lib/api/thems.ts 에 테마 히어로영역에서 사용할 API함수를 구현했습니다.
2. 라우터 설정을 통해 테마 id를 받아 사용하는 페이지를 구현하여 상단 히어로영역을 표시했습니다.
3. 404에러시 홈으로 리디렉션 시켜야하는 요구사항이 있어서, step2에서 구현한 커스텀훅을 사용했습니다.
---
4. lib/api/thems.ts에 테마 상품 리스트를 가져오는 API함수를 구현했습니다.
5. Home의 RankingSection에서 사용하는 RankingItemCard와 비교해서 rankBadge만 제외하면 같은 컴포넌트라고 생각하여 rank속성을 선택적으로 변경하고 재사용했습니다.
6. infiniteScroll은 강의자료를 참고하여 재사용가능한 훅으로 구현했습니다.
7. 테마페이지의 Grid 레이아웃도 같아 RankigSection을 참고하여 구현했습니다.
8. 마지막으로 테마페이지에서 구현한 ThemeProductSection을 return시켰습니다.