### PR TITLE
경북대 FE 정인준- 3단계 테마 상품 목록 페이지 구현하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,20 @@
   - 보내는 사람 Input Field에 userInfo의 name을 defaultValue로 입력
   - /order api를 사용하여 주문하기 기능을 완성 (authToken를 넣어야 함)
   - 주문하기 API에서 401 에러가 발생하면 로그인 페이지로 연결
+
+## step3
+
+- step2 피드백 반영
+  - api의 요청타입과 응답타입을 모두 타입으로 관리
+  - 인증토큰을 인터셉터에서 처리
+  - LoginForm 내부 useApiRequest 훅을 타입 추론으로 동작하도록 수정
+  - LoginForm useEffect 없이 값을 처리하도록 변경
+  - useSessionStorage 키 상수로 관리
+  - 인증 에러 공통 레벨에서 처리
+- 테마 상품 목록 패이지
+  - 선물 테마 섹션의 아이템을 클릭하면 테마 상품 목록 페이지로 이동
+  - `/api/themes/:themeId/info` api를 통해 선물 테마 섹션의 히어로 영역을 구현
+  - 404 에러 발생시 선물하기 홈 페이지로 이동
+  - `/api/themes/:themeId/products` api를 통해 상품 리스트 구현
+  - 무한 스크롤 기능 구현
+  - 상품 리스트가 없으면 빈 페이지를 보여줌

--- a/src/api/apiPaths.ts
+++ b/src/api/apiPaths.ts
@@ -4,5 +4,8 @@ export const API_PATHS = {
   LOGIN: "/api/login",
   PRODUCT_SUMMARY: (productId: string | number) =>
     `/api/products/${productId}/summary`,
+  THEMES_INFO: (themeId: string | number) => `/api/themes/${themeId}/info`,
+  THEMES_PRODUCTS: (themeId: string | number) =>
+    `/api/themes/${themeId}/products`,
   ORDER: "/api/order",
 };

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,5 +1,6 @@
 import { SESSION_USER_INFO_KEY } from "@/constants/storageKeys";
 import axios from "axios";
+import { toast } from "react-toastify";
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_BASE_API_URL,
@@ -28,10 +29,10 @@ axiosInstance.interceptors.response.use(
     return response.data?.data ?? response.data;
   },
   error => {
+    toast.error(error.response?.data?.data?.message || "다시 시도해주세요.");
     return Promise.reject({
       ...error,
       errorStatus: error.response?.status,
-      errorMessage: error.response?.data?.data?.message,
     });
   },
 );

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -8,6 +8,20 @@ const axiosInstance = axios.create({
   timeout: 5000,
 });
 
+axiosInstance.interceptors.request.use(
+  config => {
+    const sessionUserInfo = sessionStorage.getItem("kakaotech/userInfo");
+    if (sessionUserInfo) {
+      const { authToken } = JSON.parse(sessionUserInfo);
+      config.headers.Authorization = authToken;
+    }
+    return config;
+  },
+  error => {
+    return Promise.reject(error);
+  },
+);
+
 axiosInstance.interceptors.response.use(
   response => {
     return response.data?.data ?? response.data;

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,5 +1,4 @@
 import { SESSION_USER_INFO_KEY } from "@/constants/storageKeys";
-import { ROUTE_PATH } from "@/routes/paths";
 import axios from "axios";
 import { toast } from "react-toastify";
 
@@ -31,12 +30,6 @@ axiosInstance.interceptors.response.use(
   },
   error => {
     toast.error(error.response?.data?.data?.message || "다시 시도해주세요.");
-    if (error.response?.status === 401) {
-      window.location.href = ROUTE_PATH.LOGIN;
-    }
-    if (error.response?.status === 404) {
-      window.location.href = ROUTE_PATH.HOME;
-    }
     return Promise.reject(error);
   },
 );

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,4 +1,5 @@
 import { SESSION_USER_INFO_KEY } from "@/constants/storageKeys";
+import { ROUTE_PATH } from "@/routes/paths";
 import axios from "axios";
 import { toast } from "react-toastify";
 
@@ -30,10 +31,13 @@ axiosInstance.interceptors.response.use(
   },
   error => {
     toast.error(error.response?.data?.data?.message || "다시 시도해주세요.");
-    return Promise.reject({
-      ...error,
-      errorStatus: error.response?.status,
-    });
+    if (error.response?.status === 401) {
+      window.location.href = ROUTE_PATH.LOGIN;
+    }
+    if (error.response?.status === 404) {
+      window.location.href = ROUTE_PATH.HOME;
+    }
+    return Promise.reject(error);
   },
 );
 

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,3 +1,4 @@
+import { SESSION_USER_INFO_KEY } from "@/constants/storageKeys";
 import axios from "axios";
 
 const axiosInstance = axios.create({
@@ -10,7 +11,7 @@ const axiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use(
   config => {
-    const sessionUserInfo = sessionStorage.getItem("kakaotech/userInfo");
+    const sessionUserInfo = sessionStorage.getItem(SESSION_USER_INFO_KEY);
     if (sessionUserInfo) {
       const { authToken } = JSON.parse(sessionUserInfo);
       config.headers.Authorization = authToken;

--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -2,12 +2,15 @@ import { API_PATHS } from "./apiPaths";
 import axiosInstance from "./axiosInstance";
 import type { User } from "@/types/user";
 
+type PostLoginParams = {
+  email: string;
+  password: string;
+};
+
+type PostLoginResult = User;
+
 export const postLogin = async (
-  email: string,
-  password: string,
-): Promise<User> => {
-  return await axiosInstance.post(API_PATHS.LOGIN, {
-    email,
-    password,
-  });
+  params: PostLoginParams,
+): Promise<PostLoginResult> => {
+  return await axiosInstance.post(API_PATHS.LOGIN, params);
 };

--- a/src/api/order.ts
+++ b/src/api/order.ts
@@ -4,13 +4,8 @@ import type { OrderRequest } from "@/types/order";
 
 type PostOrderParams = {
   orderData: OrderRequest;
-  token: string;
 };
 
 export const postOrder = async (params: PostOrderParams) => {
-  return await axiosInstance.post(API_PATHS.ORDER, params.orderData, {
-    headers: {
-      Authorization: params.token,
-    },
-  });
+  return await axiosInstance.post(API_PATHS.ORDER, params.orderData);
 };

--- a/src/api/order.ts
+++ b/src/api/order.ts
@@ -2,10 +2,15 @@ import { API_PATHS } from "./apiPaths";
 import axiosInstance from "./axiosInstance";
 import type { OrderRequest } from "@/types/order";
 
-export const postOrder = async (orderData: OrderRequest, token: string) => {
-  return await axiosInstance.post(API_PATHS.ORDER, orderData, {
+type PostOrderParams = {
+  orderData: OrderRequest;
+  token: string;
+};
+
+export const postOrder = async (params: PostOrderParams) => {
+  return await axiosInstance.post(API_PATHS.ORDER, params.orderData, {
     headers: {
-      Authorization: token,
+      Authorization: params.token,
     },
   });
 };

--- a/src/api/productSummary.ts
+++ b/src/api/productSummary.ts
@@ -2,10 +2,16 @@ import { API_PATHS } from "./apiPaths";
 import axiosInstance from "./axiosInstance";
 import type { GiftSummary } from "@/types/gift";
 
+type FetchProductsSummaryParams = {
+  productId: number;
+};
+
+type FetchProductsSummaryResult = GiftSummary;
+
 export const fetchProductsSummary = async (
-  productId: number,
-): Promise<GiftSummary> => {
-  return await axiosInstance.get(API_PATHS.PRODUCT_SUMMARY(productId), {
-    params: { productId },
+  params: FetchProductsSummaryParams,
+): Promise<FetchProductsSummaryResult> => {
+  return await axiosInstance.get(API_PATHS.PRODUCT_SUMMARY(params.productId), {
+    params: { productId: params.productId },
   });
 };

--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -2,11 +2,15 @@ import { API_PATHS } from "./apiPaths";
 import axiosInstance from "./axiosInstance";
 import type { TargetType, RankType, Gift } from "@/types/gift";
 
+type FetchProductsRankingParams = {
+  targetType: TargetType;
+  rankType: RankType;
+};
+
+type FetchProductsRankingResult = Gift[];
+
 export const fetchProductsRanking = async (
-  targetType: TargetType,
-  rankType: RankType,
-): Promise<Gift[]> => {
-  return await axiosInstance.get(API_PATHS.PRODUCTS_RANKING, {
-    params: { targetType, rankType },
-  });
+  params: FetchProductsRankingParams,
+): Promise<FetchProductsRankingResult> => {
+  return await axiosInstance.get(API_PATHS.PRODUCTS_RANKING, { params });
 };

--- a/src/api/theme.ts
+++ b/src/api/theme.ts
@@ -2,6 +2,8 @@ import { API_PATHS } from "./apiPaths";
 import axiosInstance from "./axiosInstance";
 import type { Theme } from "@/types/theme";
 
-export const fetchTheme = async (): Promise<Theme[]> => {
+type FetchThemeResult = Theme[];
+
+export const fetchTheme = async (): Promise<FetchThemeResult> => {
   return await axiosInstance.get(API_PATHS.THEMES);
 };

--- a/src/api/themesInfo.ts
+++ b/src/api/themesInfo.ts
@@ -1,4 +1,4 @@
-import type { ThemesInfo } from "@/types/theme";
+import type { ThemeInfo } from "@/types/theme";
 import { API_PATHS } from "./apiPaths";
 import axiosInstance from "./axiosInstance";
 
@@ -6,7 +6,7 @@ type FetchThemesInfoParams = {
   themeId: number;
 };
 
-type FetchThemesInfoResult = ThemesInfo;
+type FetchThemesInfoResult = ThemeInfo;
 
 export const fetchThemesInfo = async (
   params: FetchThemesInfoParams,

--- a/src/api/themesInfo.ts
+++ b/src/api/themesInfo.ts
@@ -1,0 +1,15 @@
+import type { ThemesInfo } from "@/types/theme";
+import { API_PATHS } from "./apiPaths";
+import axiosInstance from "./axiosInstance";
+
+type FetchThemesInfoParams = {
+  themeId: number;
+};
+
+type FetchThemesInfoResult = ThemesInfo;
+
+export const fetchThemesInfo = async (
+  params: FetchThemesInfoParams,
+): Promise<FetchThemesInfoResult> => {
+  return await axiosInstance.get(API_PATHS.THEMES_INFO(params.themeId));
+};

--- a/src/api/themesProducts.ts
+++ b/src/api/themesProducts.ts
@@ -1,4 +1,4 @@
-import type { ThemesProduct } from "@/types/theme";
+import type { ThemeProduct } from "@/types/theme";
 import { API_PATHS } from "./apiPaths";
 import axiosInstance from "./axiosInstance";
 
@@ -9,7 +9,7 @@ type fetchThemesProductsParams = {
 };
 
 type FetchThemesProductsResult = {
-  list: ThemesProduct[];
+  list: ThemeProduct[];
   cursor: number;
   hasMoreList: boolean;
 };

--- a/src/api/themesProducts.ts
+++ b/src/api/themesProducts.ts
@@ -17,7 +17,7 @@ type FetchThemesProductsResult = {
 export const fetchThemesProducts = async ({
   themeId,
   cursor = 0,
-  limit = 20,
+  limit = 10,
 }: fetchThemesProductsParams): Promise<FetchThemesProductsResult> => {
   return await axiosInstance.get(API_PATHS.THEMES_PRODUCTS(themeId), {
     params: {

--- a/src/api/themesProducts.ts
+++ b/src/api/themesProducts.ts
@@ -2,13 +2,13 @@ import type { ThemeProduct } from "@/types/theme";
 import { API_PATHS } from "./apiPaths";
 import axiosInstance from "./axiosInstance";
 
-type fetchThemesProductsParams = {
+export type fetchThemesProductsParams = {
   themeId: number;
   cursor?: number;
   limit?: number;
 };
 
-type FetchThemesProductsResult = {
+export type FetchThemesProductsResult = {
   list: ThemeProduct[];
   cursor: number;
   hasMoreList: boolean;

--- a/src/api/themesProducts.ts
+++ b/src/api/themesProducts.ts
@@ -1,0 +1,28 @@
+import type { ThemesProduct } from "@/types/theme";
+import { API_PATHS } from "./apiPaths";
+import axiosInstance from "./axiosInstance";
+
+type fetchThemesProductsParams = {
+  themeId: number;
+  cursor?: number;
+  limit?: number;
+};
+
+type FetchThemesProductsResult = {
+  list: ThemesProduct[];
+  cursor: number;
+  hasMoreList: boolean;
+};
+
+export const fetchThemesProducts = async ({
+  themeId,
+  cursor = 0,
+  limit = 20,
+}: fetchThemesProductsParams): Promise<FetchThemesProductsResult> => {
+  return await axiosInstance.get(API_PATHS.THEMES_PRODUCTS(themeId), {
+    params: {
+      cursor,
+      limit,
+    },
+  });
+};

--- a/src/components/GiftsRender.tsx
+++ b/src/components/GiftsRender.tsx
@@ -15,10 +15,10 @@ type GiftsRenderProps = {
 
 const GiftsRender = ({ selectedTypes }: GiftsRenderProps) => {
   const requestFn = useCallback(() => {
-    return fetchProductsRanking(
-      selectedTypes.targetType,
-      selectedTypes.rankType,
-    );
+    return fetchProductsRanking({
+      targetType: selectedTypes.targetType,
+      rankType: selectedTypes.rankType,
+    });
   }, [selectedTypes]);
   const { data: gifts, isLoading, isError } = useApiRequest({ requestFn });
 

--- a/src/components/PresentCategory.tsx
+++ b/src/components/PresentCategory.tsx
@@ -4,8 +4,11 @@ import { fetchTheme } from "@/api/theme";
 import type { Theme } from "@/types/theme";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import useApiRequest from "@/hooks/useApiRequest";
+import { useNavigate } from "react-router";
+import { ROUTE_PATH } from "@/routes/paths";
 
 const PresentCategory = () => {
+  const navigate = useNavigate();
   const {
     data: presentThemes,
     isLoading,
@@ -16,13 +19,23 @@ const PresentCategory = () => {
     return <></>;
   }
 
+  const handleThemeClick = (themeId: number) => {
+    navigate(`${ROUTE_PATH.THEMES.replace(":id", themeId.toString())}`);
+  };
+
   return (
     <Background>
       <CategoryTitle>선물 테마</CategoryTitle>
       {presentThemes && !isLoading ? (
         <ThemeGrid>
           {presentThemes.map(theme => (
-            <PresentTheme key={theme.themeId} theme={theme} />
+            <button
+              type="button"
+              key={theme.themeId}
+              onClick={() => handleThemeClick(theme.themeId)}
+            >
+              <PresentTheme theme={theme} />
+            </button>
           ))}
         </ThemeGrid>
       ) : (

--- a/src/components/PresentTheme.tsx
+++ b/src/components/PresentTheme.tsx
@@ -23,7 +23,6 @@ const Flex = styled.div`
   align-items: center;
   justify-content: center;
   gap: ${({ theme }) => theme.spacing.spacing1};
-  cursor: pointer;
 `;
 
 const Img = styled.img`

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -8,7 +8,6 @@ import { useUserInfo } from "@/contexts/UserInfoContext";
 import { postLogin } from "@/api/login";
 import useApiRequest from "@/hooks/useApiRequest";
 import { useEffect } from "react";
-import { toast } from "react-toastify";
 
 const LoginForm = () => {
   const navigate = useNavigate();
@@ -21,7 +20,6 @@ const LoginForm = () => {
     data: userData,
     isLoading,
     isError,
-    error,
     refetch: postLoginRequest,
   } = useApiRequest({
     requestFn: postLogin,
@@ -48,12 +46,6 @@ const LoginForm = () => {
       navigate(redirectPath || ROUTE_PATH.HOME);
     }
   }, [userData, isLoading, isError, user, location.search, navigate]);
-
-  useEffect(() => {
-    if (isError && !isLoading) {
-      toast.error(error);
-    }
-  }, [isError, isLoading, error]);
 
   return (
     <Form onSubmit={handleSubmit}>

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -7,7 +7,6 @@ import ErrorMessage from "../common/ErrorMessage";
 import { useUserInfo } from "@/contexts/UserInfoContext";
 import { postLogin } from "@/api/login";
 import useApiRequest from "@/hooks/useApiRequest";
-import type { User } from "@/types/user";
 import { useEffect } from "react";
 import { toast } from "react-toastify";
 
@@ -24,14 +23,17 @@ const LoginForm = () => {
     isError,
     error,
     refetch: postLoginRequest,
-  } = useApiRequest<User, [string, string]>({
+  } = useApiRequest({
     requestFn: postLogin,
     immediate: false,
   });
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    postLoginRequest(emailInput.value, passwordInput.value);
+    postLoginRequest({
+      email: emailInput.value,
+      password: passwordInput.value,
+    });
   };
 
   useEffect(() => {

--- a/src/components/themes/ThemesInfo.tsx
+++ b/src/components/themes/ThemesInfo.tsx
@@ -1,26 +1,31 @@
 import { fetchThemesInfo } from "@/api/themesInfo";
-import useApiRequest from "@/hooks/useApiRequest";
 import styled from "@emotion/styled";
-import { useCallback } from "react";
+import { useState } from "react";
+import type { ThemesInfo } from "@/types/theme";
+import { useNavigate } from "react-router";
+import { ROUTE_PATH } from "@/routes/paths";
 
 type ThemesInfoProps = {
   id: string | undefined;
 };
 
 const ThemesInfo = ({ id }: ThemesInfoProps) => {
-  const requestFn = useCallback(
-    () => fetchThemesInfo({ themeId: Number(id) }),
-    [id],
+  const navigate = useNavigate();
+  const [themeInfoData, setThemeInfoData] = useState<ThemesInfo | undefined>(
+    undefined,
   );
-  const {
-    data: themeInfoData,
-    isError,
-    isLoading,
-  } = useApiRequest({
-    requestFn,
-  });
 
-  if (!themeInfoData && !isLoading && isError) {
+  fetchThemesInfo({ themeId: Number(id) })
+    .then(data => {
+      setThemeInfoData(data);
+    })
+    .catch(error => {
+      if (error.response?.status === 404) {
+        navigate(ROUTE_PATH.HOME, { replace: true });
+      }
+    });
+
+  if (!themeInfoData) {
     return null;
   }
 

--- a/src/components/themes/ThemesInfo.tsx
+++ b/src/components/themes/ThemesInfo.tsx
@@ -1,7 +1,7 @@
 import { fetchThemesInfo } from "@/api/themesInfo";
 import styled from "@emotion/styled";
 import { useState } from "react";
-import type { ThemesInfo } from "@/types/theme";
+import type { ThemeInfo } from "@/types/theme";
 import { useNavigate } from "react-router";
 import { ROUTE_PATH } from "@/routes/paths";
 
@@ -11,7 +11,7 @@ type ThemesInfoProps = {
 
 const ThemesInfo = ({ id }: ThemesInfoProps) => {
   const navigate = useNavigate();
-  const [themeInfoData, setThemeInfoData] = useState<ThemesInfo | undefined>(
+  const [themeInfoData, setThemeInfoData] = useState<ThemeInfo | undefined>(
     undefined,
   );
 

--- a/src/components/themes/ThemesInfo.tsx
+++ b/src/components/themes/ThemesInfo.tsx
@@ -1,31 +1,28 @@
 import { fetchThemesInfo } from "@/api/themesInfo";
 import styled from "@emotion/styled";
-import { useState } from "react";
 import type { ThemeInfo } from "@/types/theme";
-import { useNavigate } from "react-router";
-import { ROUTE_PATH } from "@/routes/paths";
+import useApiRequest from "@/hooks/useApiRequest";
+import { useCallback } from "react";
 
 type ThemesInfoProps = {
   id: string | undefined;
 };
 
 const ThemesInfo = ({ id }: ThemesInfoProps) => {
-  const navigate = useNavigate();
-  const [themeInfoData, setThemeInfoData] = useState<ThemeInfo | undefined>(
-    undefined,
+  const requestFn = useCallback(
+    () => fetchThemesInfo({ themeId: Number(id) }),
+    [id],
   );
 
-  fetchThemesInfo({ themeId: Number(id) })
-    .then(data => {
-      setThemeInfoData(data);
-    })
-    .catch(error => {
-      if (error.response?.status === 404) {
-        navigate(ROUTE_PATH.HOME, { replace: true });
-      }
-    });
+  const {
+    data: themeInfoData,
+    isLoading,
+    isError,
+  } = useApiRequest<ThemeInfo>({
+    requestFn,
+  });
 
-  if (!themeInfoData) {
+  if (!themeInfoData && isLoading && !isError) {
     return null;
   }
 

--- a/src/components/themes/ThemesInfo.tsx
+++ b/src/components/themes/ThemesInfo.tsx
@@ -1,6 +1,7 @@
 import { fetchThemesInfo } from "@/api/themesInfo";
 import useApiRequest from "@/hooks/useApiRequest";
-import { useCallback, useEffect } from "react";
+import styled from "@emotion/styled";
+import { useCallback } from "react";
 
 type ThemesInfoProps = {
   id: string | undefined;
@@ -19,23 +20,54 @@ const ThemesInfo = ({ id }: ThemesInfoProps) => {
     requestFn,
   });
 
-  useEffect(() => {
-    if (!themeInfoData && !isLoading && isError) {
-      console.error("Failed to fetch theme information");
-    }
-  }, [themeInfoData, isError, isLoading]);
+  if (!themeInfoData && !isLoading && isError) {
+    return null;
+  }
 
   return (
-    <div>
+    <InfoSection backgroundColor={themeInfoData?.backgroundColor}>
       {themeInfoData && (
-        <div>
-          <h1>{themeInfoData.name}</h1>
-          <h2>{themeInfoData.title}</h2>
-          <p>{themeInfoData.description}</p>
-        </div>
+        <>
+          <NameP>{themeInfoData.name}</NameP>
+          <TitleH5>{themeInfoData.title}</TitleH5>
+          <DescriptionP>{themeInfoData.description}</DescriptionP>
+        </>
       )}
-    </div>
+    </InfoSection>
   );
 };
 
 export default ThemesInfo;
+
+const InfoSection = styled.section<{ backgroundColor?: string }>`
+  margin: 0px;
+  padding: ${({ theme }) =>
+    `${theme.spacing.spacing7} ${theme.spacing.spacing4} ${theme.spacing.spacing6}`};
+  background-color: ${({ theme, backgroundColor }) =>
+    backgroundColor || theme.colors.semantic.background.default};
+`;
+
+const NameP = styled.p`
+  font-size: ${({ theme }) => theme.typography.label1Bold.fontSize};
+  font-weight: ${({ theme }) => theme.typography.label1Bold.fontWeight};
+  line-height: ${({ theme }) => theme.typography.label1Bold.lineHeight};
+  color: ${({ theme }) => theme.colors.gray.gray100};
+`;
+
+const TitleH5 = styled.h5`
+  margin: ${({ theme }) =>
+    `${theme.spacing.spacing2} 0 ${theme.spacing.spacing1}`};
+  font-size: ${({ theme }) => theme.typography.title1Bold.fontSize};
+  font-weight: ${({ theme }) => theme.typography.title1Bold.fontWeight};
+  line-height: ${({ theme }) => theme.typography.title1Bold.lineHeight};
+  color: ${({ theme }) => theme.colors.gray.gray00};
+`;
+
+const DescriptionP = styled.p`
+  margin: 0px;
+  padding: 0px;
+  font-size: ${({ theme }) => theme.typography.subtitle1Regular.fontSize};
+  font-weight: ${({ theme }) => theme.typography.subtitle1Regular.fontWeight};
+  line-height: ${({ theme }) => theme.typography.subtitle1Regular.lineHeight};
+  color: ${({ theme }) => theme.colors.gray.gray200};
+`;

--- a/src/components/themes/ThemesInfo.tsx
+++ b/src/components/themes/ThemesInfo.tsx
@@ -1,0 +1,41 @@
+import { fetchThemesInfo } from "@/api/themesInfo";
+import useApiRequest from "@/hooks/useApiRequest";
+import { useCallback, useEffect } from "react";
+
+type ThemesInfoProps = {
+  id: string | undefined;
+};
+
+const ThemesInfo = ({ id }: ThemesInfoProps) => {
+  const requestFn = useCallback(
+    () => fetchThemesInfo({ themeId: Number(id) }),
+    [id],
+  );
+  const {
+    data: themeInfoData,
+    isError,
+    isLoading,
+  } = useApiRequest({
+    requestFn,
+  });
+
+  useEffect(() => {
+    if (!themeInfoData && !isLoading && isError) {
+      console.error("Failed to fetch theme information");
+    }
+  }, [themeInfoData, isError, isLoading]);
+
+  return (
+    <div>
+      {themeInfoData && (
+        <div>
+          <h1>{themeInfoData.name}</h1>
+          <h2>{themeInfoData.title}</h2>
+          <p>{themeInfoData.description}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ThemesInfo;

--- a/src/components/themes/ThemesItem.tsx
+++ b/src/components/themes/ThemesItem.tsx
@@ -1,0 +1,66 @@
+import type { ThemesProduct } from "@/types/theme";
+import styled from "@emotion/styled";
+
+type ThemesItemProps = {
+  product: ThemesProduct;
+};
+
+const ThemesItem = ({ product }: ThemesItemProps) => {
+  return (
+    <Container>
+      <div>
+        <Img src={product.imageURL} alt={product.name} />
+        <BrandName>{product.brandInfo.name}</BrandName>
+        <ProductName>{product.name}</ProductName>
+      </div>
+      <Price>
+        {product.price.sellingPrice} <Span>원</Span>
+      </Price>
+    </Container>
+  );
+};
+
+export default ThemesItem;
+
+const Container = styled.div`
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  justify-content: space-between;
+  margin: 0;
+`;
+
+const Img = styled.img`
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  object-position: center center;
+  border-radius: 4px;
+  margin: 0;
+`;
+
+const BrandName = styled.p`
+  font-size: ${({ theme }) => theme.typography.label1Regular.fontSize};
+  font-weight: ${({ theme }) => theme.typography.label1Regular.fontWeight};
+  line-height: ${({ theme }) => theme.typography.label1Regular.lineHeight};
+  color: ${({ theme }) => theme.colors.semantic.text.sub};
+`;
+
+const ProductName = styled.h6`
+  font-size: ${({ theme }) => theme.typography.label1Regular.fontSize};
+  font-weight: ${({ theme }) => theme.typography.label1Regular.fontWeight};
+  line-height: ${({ theme }) => theme.typography.label1Regular.lineHeight};
+  color: ${({ theme }) => theme.colors.semantic.text.default};
+  margin-bottom: ${({ theme }) => theme.spacing.spacing1};
+`;
+
+const Price = styled.p`
+  font-size: ${({ theme }) => theme.typography.title2Bold.fontSize};
+  font-weight: ${({ theme }) => theme.typography.title2Bold.fontWeight};
+  line-height: ${({ theme }) => theme.typography.title2Bold.lineHeight};
+  color: ${({ theme }) => theme.colors.semantic.text.default};
+`;
+
+const Span = styled.span`
+  font-weight: ${({ theme }) => theme.typography.title2Regular.fontWeight};
+`;

--- a/src/components/themes/ThemesItem.tsx
+++ b/src/components/themes/ThemesItem.tsx
@@ -1,8 +1,8 @@
-import type { ThemesProduct } from "@/types/theme";
+import type { ThemeProduct } from "@/types/theme";
 import styled from "@emotion/styled";
 
 type ThemesItemProps = {
-  product: ThemesProduct;
+  product: ThemeProduct;
 };
 
 const ThemesItem = ({ product }: ThemesItemProps) => {

--- a/src/components/themes/ThemesProducts.tsx
+++ b/src/components/themes/ThemesProducts.tsx
@@ -1,0 +1,41 @@
+import { fetchThemesProducts } from "@/api/themesProducts";
+import useApiRequest from "@/hooks/useApiRequest";
+import { useCallback, useEffect } from "react";
+
+type ThemesProductsProps = {
+  id: string | undefined;
+};
+
+const ThemesProducts = ({ id }: ThemesProductsProps) => {
+  const requestFn = useCallback(
+    () => fetchThemesProducts({ themeId: Number(id) }),
+    [id],
+  );
+  const {
+    data: themeProductsData,
+    isError,
+    isLoading,
+  } = useApiRequest({
+    requestFn,
+  });
+
+  useEffect(() => {
+    if (!themeProductsData && !isLoading && isError) {
+      console.error("Failed to fetch theme products");
+    }
+  }, [themeProductsData, isError, isLoading]);
+
+  return (
+    <div>
+      {themeProductsData && (
+        <ul>
+          {themeProductsData.list.map(product => (
+            <li key={product.id}>{product.name}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default ThemesProducts;

--- a/src/components/themes/ThemesProducts.tsx
+++ b/src/components/themes/ThemesProducts.tsx
@@ -1,6 +1,10 @@
+import styled from "@emotion/styled";
 import { fetchThemesProducts } from "@/api/themesProducts";
 import useApiRequest from "@/hooks/useApiRequest";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
+import ThemesItem from "./ThemesItem";
+import { Link } from "react-router";
+import { ROUTE_PATH } from "@/routes/paths";
 
 type ThemesProductsProps = {
   id: string | undefined;
@@ -19,23 +23,38 @@ const ThemesProducts = ({ id }: ThemesProductsProps) => {
     requestFn,
   });
 
-  useEffect(() => {
-    if (!themeProductsData && !isLoading && isError) {
-      console.error("Failed to fetch theme products");
-    }
-  }, [themeProductsData, isError, isLoading]);
+  if (!themeProductsData && !isLoading && isError) {
+    console.error("Failed to fetch theme products");
+  }
 
   return (
-    <div>
+    <ProductsSection>
       {themeProductsData && (
-        <ul>
+        <ProductsGrid>
           {themeProductsData.list.map(product => (
-            <li key={product.id}>{product.name}</li>
+            <Link
+              to={ROUTE_PATH.ORDER.replace(":id", String(product.id))}
+              key={product.id}
+            >
+              <ThemesItem product={product} />
+            </Link>
           ))}
-        </ul>
+        </ProductsGrid>
       )}
-    </div>
+    </ProductsSection>
   );
 };
 
 export default ThemesProducts;
+
+const ProductsSection = styled.section`
+  margin: 0;
+  padding: ${({ theme }) => theme.spacing.spacing4};
+  background-color: ${({ theme }) => theme.colors.semantic.background.default};
+`;
+
+const ProductsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: ${({ theme }) => `${theme.spacing.spacing6} ${theme.spacing.spacing2}`};
+`;

--- a/src/components/themes/ThemesProducts.tsx
+++ b/src/components/themes/ThemesProducts.tsx
@@ -1,39 +1,73 @@
 import styled from "@emotion/styled";
 import { fetchThemesProducts } from "@/api/themesProducts";
 import useApiRequest from "@/hooks/useApiRequest";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import ThemesItem from "./ThemesItem";
 import { Link } from "react-router";
 import { ROUTE_PATH } from "@/routes/paths";
 import BoxMessage from "../common/BoxMessage";
+import type { ThemesProduct } from "@/types/theme";
+import LoadingSpinner from "../common/LoadingSpinner";
 
 type ThemesProductsProps = {
   id: string | undefined;
 };
 
 const ThemesProducts = ({ id }: ThemesProductsProps) => {
+  const [items, setItems] = useState<ThemesProduct[]>([]);
+  const [cursor, setCursor] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const loader = useRef(null);
+
   const requestFn = useCallback(
-    () => fetchThemesProducts({ themeId: Number(id) }),
-    [id],
+    () => fetchThemesProducts({ themeId: Number(id), cursor, limit: 20 }),
+    [id, cursor],
   );
   const {
     data: themeProductsData,
     isError,
     isLoading,
+    refetch,
   } = useApiRequest({
     requestFn,
+    immediate: false,
   });
 
+  useEffect(() => {
+    if (themeProductsData && !isLoading && !isError) {
+      setItems(prev => [...prev, ...themeProductsData.list]);
+      setCursor(themeProductsData.cursor);
+      setHasMore(themeProductsData.hasMoreList);
+    }
+  }, [themeProductsData, isLoading, isError]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && hasMore) {
+          refetch();
+        }
+      },
+      { threshold: 1.0 },
+    );
+
+    const el = loader.current;
+    if (el) observer.observe(el);
+
+    return () => {
+      if (el) observer.unobserve(el);
+    };
+  }, [loader, hasMore, refetch]);
+
   if (!themeProductsData && !isLoading && isError) {
-    console.error("Failed to fetch theme products");
+    return null;
   }
-  console.log("themeProductsData", themeProductsData?.list);
 
   return (
     <ProductsSection>
-      {themeProductsData?.list && themeProductsData.list.length > 0 ? (
+      {items?.length > 0 && (
         <ProductsGrid>
-          {themeProductsData.list.map(product => (
+          {items.map(product => (
             <Link
               to={ROUTE_PATH.ORDER.replace(":id", String(product.id))}
               key={product.id}
@@ -42,9 +76,12 @@ const ThemesProducts = ({ id }: ThemesProductsProps) => {
             </Link>
           ))}
         </ProductsGrid>
-      ) : (
+      )}
+      {isLoading && <LoadingSpinner height="40px" />}
+      {items?.length === 0 && !isLoading && !themeProductsData && (
         <BoxMessage message="상품이 없습니다." height="240px" />
       )}
+      <div ref={loader} style={{ height: "20px" }} />
     </ProductsSection>
   );
 };

--- a/src/components/themes/ThemesProducts.tsx
+++ b/src/components/themes/ThemesProducts.tsx
@@ -5,6 +5,7 @@ import { useCallback } from "react";
 import ThemesItem from "./ThemesItem";
 import { Link } from "react-router";
 import { ROUTE_PATH } from "@/routes/paths";
+import BoxMessage from "../common/BoxMessage";
 
 type ThemesProductsProps = {
   id: string | undefined;
@@ -26,10 +27,11 @@ const ThemesProducts = ({ id }: ThemesProductsProps) => {
   if (!themeProductsData && !isLoading && isError) {
     console.error("Failed to fetch theme products");
   }
+  console.log("themeProductsData", themeProductsData?.list);
 
   return (
     <ProductsSection>
-      {themeProductsData && (
+      {themeProductsData?.list && themeProductsData.list.length > 0 ? (
         <ProductsGrid>
           {themeProductsData.list.map(product => (
             <Link
@@ -40,6 +42,8 @@ const ThemesProducts = ({ id }: ThemesProductsProps) => {
             </Link>
           ))}
         </ProductsGrid>
+      ) : (
+        <BoxMessage message="상품이 없습니다." height="240px" />
       )}
     </ProductsSection>
   );

--- a/src/components/themes/ThemesProducts.tsx
+++ b/src/components/themes/ThemesProducts.tsx
@@ -6,7 +6,7 @@ import ThemesItem from "./ThemesItem";
 import { Link } from "react-router";
 import { ROUTE_PATH } from "@/routes/paths";
 import BoxMessage from "../common/BoxMessage";
-import type { ThemesProduct } from "@/types/theme";
+import type { ThemeProduct } from "@/types/theme";
 import LoadingSpinner from "../common/LoadingSpinner";
 
 type ThemesProductsProps = {
@@ -14,7 +14,7 @@ type ThemesProductsProps = {
 };
 
 const ThemesProducts = ({ id }: ThemesProductsProps) => {
-  const [items, setItems] = useState<ThemesProduct[]>([]);
+  const [items, setItems] = useState<ThemeProduct[]>([]);
   const [cursor, setCursor] = useState(0);
   const [hasMore, setHasMore] = useState(true);
   const loader = useRef(null);

--- a/src/components/themes/ThemesProducts.tsx
+++ b/src/components/themes/ThemesProducts.tsx
@@ -78,9 +78,11 @@ const ThemesProducts = ({ id }: ThemesProductsProps) => {
         </ProductsGrid>
       )}
       {isLoading && <LoadingSpinner height="40px" />}
-      {items?.length === 0 && !isLoading && !themeProductsData && (
-        <BoxMessage message="상품이 없습니다." height="240px" />
-      )}
+      {items?.length === 0 &&
+        !isLoading &&
+        themeProductsData?.list.length === 0 && (
+          <BoxMessage message="상품이 없습니다." height="240px" />
+        )}
       <div ref={loader} style={{ height: "20px" }} />
     </ProductsSection>
   );

--- a/src/components/themes/ThemesProducts.tsx
+++ b/src/components/themes/ThemesProducts.tsx
@@ -1,65 +1,36 @@
 import styled from "@emotion/styled";
 import { fetchThemesProducts } from "@/api/themesProducts";
-import useApiRequest from "@/hooks/useApiRequest";
-import { useCallback, useEffect, useRef, useState } from "react";
 import ThemesItem from "./ThemesItem";
 import { Link } from "react-router";
 import { ROUTE_PATH } from "@/routes/paths";
 import BoxMessage from "../common/BoxMessage";
 import type { ThemeProduct } from "@/types/theme";
 import LoadingSpinner from "../common/LoadingSpinner";
+import useInfiniteQuery from "@/hooks/useInfiniteQuery";
+import type {
+  fetchThemesProductsParams,
+  FetchThemesProductsResult,
+} from "@/api/themesProducts";
 
 type ThemesProductsProps = {
   id: string | undefined;
 };
 
 const ThemesProducts = ({ id }: ThemesProductsProps) => {
-  const [items, setItems] = useState<ThemeProduct[]>([]);
-  const [cursor, setCursor] = useState(0);
-  const [hasMore, setHasMore] = useState(true);
-  const loader = useRef(null);
-
-  const requestFn = useCallback(
-    () => fetchThemesProducts({ themeId: Number(id), cursor, limit: 20 }),
-    [id, cursor],
-  );
-  const {
-    data: themeProductsData,
-    isError,
-    isLoading,
-    refetch,
-  } = useApiRequest({
-    requestFn,
-    immediate: false,
+  const { items, isLoading, isError, loaderRef } = useInfiniteQuery<
+    FetchThemesProductsResult,
+    ThemeProduct,
+    fetchThemesProductsParams
+  >({
+    fetcher: ({ themeId, cursor, limit }) =>
+      fetchThemesProducts({ themeId, cursor, limit }),
+    initialParams: { themeId: Number(id), cursor: 0, limit: 20 },
+    getList: res => res.list,
+    getCursor: res => res.cursor,
+    getHasMore: res => res.hasMoreList,
   });
 
-  useEffect(() => {
-    if (themeProductsData && !isLoading && !isError) {
-      setItems(prev => [...prev, ...themeProductsData.list]);
-      setCursor(themeProductsData.cursor);
-      setHasMore(themeProductsData.hasMoreList);
-    }
-  }, [themeProductsData, isLoading, isError]);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting && hasMore) {
-          refetch();
-        }
-      },
-      { threshold: 1.0 },
-    );
-
-    const el = loader.current;
-    if (el) observer.observe(el);
-
-    return () => {
-      if (el) observer.unobserve(el);
-    };
-  }, [loader, hasMore, refetch]);
-
-  if (!themeProductsData && !isLoading && isError) {
+  if (!items && !isLoading && isError) {
     return null;
   }
 
@@ -78,12 +49,10 @@ const ThemesProducts = ({ id }: ThemesProductsProps) => {
         </ProductsGrid>
       )}
       {isLoading && <LoadingSpinner height="40px" />}
-      {items?.length === 0 &&
-        !isLoading &&
-        themeProductsData?.list.length === 0 && (
-          <BoxMessage message="상품이 없습니다." height="240px" />
-        )}
-      <div ref={loader} style={{ height: "20px" }} />
+      {items?.length === 0 && !isLoading && (
+        <BoxMessage message="상품이 없습니다." height="240px" />
+      )}
+      <div ref={loaderRef} style={{ height: "20px" }} />
     </ProductsSection>
   );
 };

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -1,0 +1,1 @@
+export const SESSION_USER_INFO_KEY = "kakaotech/userInfo";

--- a/src/contexts/UserInfoContext.tsx
+++ b/src/contexts/UserInfoContext.tsx
@@ -1,3 +1,4 @@
+import { SESSION_USER_INFO_KEY } from "@/constants/storageKeys";
 import useSessionStorage from "@/hooks/useSessionStorage";
 import React, { createContext, useContext } from "react";
 
@@ -19,7 +20,7 @@ export const UserInfoProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const userInfo = useSessionStorage<UserInfo>("kakaotech/userInfo", {
+  const userInfo = useSessionStorage<UserInfo>(SESSION_USER_INFO_KEY, {
     email: undefined,
     name: undefined,
     authToken: undefined,

--- a/src/hooks/useApiRequest.ts
+++ b/src/hooks/useApiRequest.ts
@@ -12,7 +12,6 @@ const useApiRequest = <TData = unknown, TArgs extends unknown[] = []>({
   const [data, setData] = useState<TData | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(immediate);
   const [isError, setIsError] = useState(false);
-  const [error, setError] = useState("");
 
   const fetchData = useCallback(
     (...args: TArgs) => {
@@ -22,9 +21,8 @@ const useApiRequest = <TData = unknown, TArgs extends unknown[] = []>({
         .then(response => {
           setData(response);
         })
-        .catch(err => {
+        .catch(() => {
           setIsError(true);
-          setError(err.errorMessage);
         })
         .finally(() => {
           setIsLoading(false);
@@ -43,7 +41,6 @@ const useApiRequest = <TData = unknown, TArgs extends unknown[] = []>({
     data,
     isLoading,
     isError,
-    error,
     refetch: fetchData,
   };
 };

--- a/src/hooks/useApiRequest.ts
+++ b/src/hooks/useApiRequest.ts
@@ -1,4 +1,6 @@
+import { ROUTE_PATH } from "@/routes/paths";
 import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router";
 
 type UseApiRequestProps<TData, TArgs extends unknown[] = []> = {
   requestFn: (...args: TArgs) => Promise<TData>;
@@ -9,6 +11,7 @@ const useApiRequest = <TData = unknown, TArgs extends unknown[] = []>({
   requestFn,
   immediate = true,
 }: UseApiRequestProps<TData, TArgs>) => {
+  const navigate = useNavigate();
   const [data, setData] = useState<TData | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(immediate);
   const [isError, setIsError] = useState(false);
@@ -21,14 +24,19 @@ const useApiRequest = <TData = unknown, TArgs extends unknown[] = []>({
         .then(response => {
           setData(response);
         })
-        .catch(() => {
+        .catch(error => {
           setIsError(true);
+          if (error.response?.status === 401) {
+            navigate(ROUTE_PATH.LOGIN, { replace: true });
+          } else if (error.response?.status === 404) {
+            navigate(ROUTE_PATH.HOME, { replace: true });
+          }
         })
         .finally(() => {
           setIsLoading(false);
         });
     },
-    [requestFn],
+    [requestFn, navigate],
   );
 
   useEffect(() => {

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type UseInViewOptions = {
+  callback?: () => void;
+  threshold?: number;
+  rootMargin?: string;
+};
+
+export const useInView = (options: UseInViewOptions = {}) => {
+  const { callback, threshold = 0.1, rootMargin = "50px" } = options;
+
+  const [inView, setInView] = useState(false);
+  const elementRef = useRef<HTMLDivElement>(null);
+
+  const handleIntersection = useCallback(
+    ([entry]: IntersectionObserverEntry[]) => {
+      const isIntersecting = entry.isIntersecting;
+
+      setInView(isIntersecting);
+
+      if (isIntersecting) {
+        callback?.();
+      }
+    },
+    [callback],
+  );
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(handleIntersection, {
+      threshold,
+      rootMargin,
+    });
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [handleIntersection, threshold, rootMargin]);
+
+  return {
+    ref: elementRef,
+    inView,
+  };
+};

--- a/src/hooks/useInfiniteQuery.ts
+++ b/src/hooks/useInfiniteQuery.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useState } from "react";
+import useApiRequest from "./useApiRequest";
+import { useInView } from "./useInView";
+
+type UseInfiniteQueryProps<TRes, TItem, TParams> = {
+  fetcher: (params: TParams) => Promise<TRes>;
+  initialParams: TParams;
+  getList: (res: TRes) => TItem[];
+  getCursor: (res: TRes) => number;
+  getHasMore: (res: TRes) => boolean;
+};
+
+function useInfiniteQuery<TRes, TItem, TParams>({
+  fetcher,
+  initialParams,
+  getList,
+  getCursor,
+  getHasMore,
+}: UseInfiniteQueryProps<TRes, TItem, TParams>) {
+  const [items, setItems] = useState<TItem[]>([]);
+  const [cursor, setCursor] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+
+  const requestFn = useCallback(
+    () => fetcher({ ...initialParams, cursor, limit: 20 }),
+    [cursor, initialParams, fetcher],
+  );
+  const { data, isError, isLoading, refetch } = useApiRequest({
+    requestFn,
+    immediate: false,
+  });
+
+  useEffect(() => {
+    if (data && !isLoading && !isError) {
+      setItems(prev => [...prev, ...getList(data)]);
+      setCursor(getCursor(data));
+      setHasMore(getHasMore(data));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, isLoading, isError]);
+
+  const { ref: loader } = useInView({
+    callback: () => {
+      if (hasMore && !isLoading) {
+        refetch();
+      }
+    },
+    threshold: 1,
+    rootMargin: "50px",
+  });
+
+  return {
+    items,
+    isLoading,
+    isError,
+    loaderRef: loader,
+  };
+}
+
+export default useInfiniteQuery;

--- a/src/hooks/useInfiniteQuery.ts
+++ b/src/hooks/useInfiniteQuery.ts
@@ -31,7 +31,12 @@ function useInfiniteQuery<TRes, TItem, TParams>({
   });
 
   useEffect(() => {
-    if (data && !isLoading && !isError) {
+    if (
+      data &&
+      !isLoading &&
+      !isError &&
+      (!getHasMore(data) || cursor !== getCursor(data))
+    ) {
       setItems(prev => [...prev, ...getList(data)]);
       setCursor(getCursor(data));
       setHasMore(getHasMore(data));

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -88,7 +88,7 @@ const OrderPage = () => {
       })),
     };
 
-    postOrder({ orderData: orderRequestData, token: userInfo?.authToken || "" })
+    postOrder({ orderData: orderRequestData })
       .then(() => {
         alert(
           [

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -15,7 +15,6 @@ import type { SubmitHandler } from "react-hook-form";
 import type { OrderFormValue } from "@/types/order";
 import { fetchProductsSummary } from "@/api/productSummary";
 import useApiRequest from "@/hooks/useApiRequest";
-import { toast } from "react-toastify";
 import type { OrderRequest } from "@/types/order";
 import { postOrder } from "@/api/order";
 
@@ -56,17 +55,15 @@ const OrderPage = () => {
     data: gift,
     isLoading,
     isError,
-    error,
   } = useApiRequest({
     requestFn,
   });
 
   useEffect(() => {
     if (!gift && !isLoading && isError) {
-      toast.error(error);
       navigate(ROUTE_PATH.HOME, { replace: true });
     }
-  }, [gift, isLoading, isError, navigate, error]);
+  }, [gift, isLoading, isError, navigate]);
 
   if (!gift) return null;
 
@@ -102,9 +99,6 @@ const OrderPage = () => {
         navigate(ROUTE_PATH.HOME, { replace: true });
       })
       .catch(error => {
-        toast.error(
-          error.errorMessage || "주문에 실패했습니다. 다시 시도해주세요.",
-        );
         if (error.errorStatus === 401) {
           navigate(ROUTE_PATH.LOGIN, { replace: true });
           return;

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -85,25 +85,18 @@ const OrderPage = () => {
       })),
     };
 
-    postOrder({ orderData: orderRequestData })
-      .then(() => {
-        alert(
-          [
-            "주문이 완료되었습니다.",
-            `상품명: ${gift.name}`,
-            `구매 수량: ${totalCount}개`,
-            `보낸 사람: ${data.sender}`,
-            `메시지: ${data.message}`,
-          ].join("\n"),
-        );
-        navigate(ROUTE_PATH.HOME, { replace: true });
-      })
-      .catch(error => {
-        if (error.errorStatus === 401) {
-          navigate(ROUTE_PATH.LOGIN, { replace: true });
-          return;
-        }
-      });
+    postOrder({ orderData: orderRequestData }).then(() => {
+      alert(
+        [
+          "주문이 완료되었습니다.",
+          `상품명: ${gift.name}`,
+          `구매 수량: ${totalCount}개`,
+          `보낸 사람: ${data.sender}`,
+          `메시지: ${data.message}`,
+        ].join("\n"),
+      );
+      navigate(ROUTE_PATH.HOME, { replace: true });
+    });
   };
 
   return (

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -85,18 +85,24 @@ const OrderPage = () => {
       })),
     };
 
-    postOrder({ orderData: orderRequestData }).then(() => {
-      alert(
-        [
-          "주문이 완료되었습니다.",
-          `상품명: ${gift.name}`,
-          `구매 수량: ${totalCount}개`,
-          `보낸 사람: ${data.sender}`,
-          `메시지: ${data.message}`,
-        ].join("\n"),
-      );
-      navigate(ROUTE_PATH.HOME, { replace: true });
-    });
+    postOrder({ orderData: orderRequestData })
+      .then(() => {
+        alert(
+          [
+            "주문이 완료되었습니다.",
+            `상품명: ${gift.name}`,
+            `구매 수량: ${totalCount}개`,
+            `보낸 사람: ${data.sender}`,
+            `메시지: ${data.message}`,
+          ].join("\n"),
+        );
+        navigate(ROUTE_PATH.HOME, { replace: true });
+      })
+      .catch(error => {
+        if (error.response?.status === 401) {
+          navigate(ROUTE_PATH.LOGIN, { replace: true });
+        }
+      });
   };
 
   return (

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -48,7 +48,10 @@ const OrderPage = () => {
   }, [location.pathname, navigate, userInfo]);
 
   const { id } = useParams<{ id: string }>();
-  const requestFn = useCallback(() => fetchProductsSummary(Number(id)), [id]);
+  const requestFn = useCallback(
+    () => fetchProductsSummary({ productId: Number(id) }),
+    [id],
+  );
   const {
     data: gift,
     isLoading,
@@ -85,7 +88,7 @@ const OrderPage = () => {
       })),
     };
 
-    postOrder(orderRequestData, userInfo?.authToken || "")
+    postOrder({ orderData: orderRequestData, token: userInfo?.authToken || "" })
       .then(() => {
         alert(
           [

--- a/src/pages/ThemesPage.tsx
+++ b/src/pages/ThemesPage.tsx
@@ -1,6 +1,7 @@
 import TheHeader from "@/components/layout/TheHeader";
 import ThemesInfo from "@/components/themes/ThemesInfo";
 import ThemesProducts from "@/components/themes/ThemesProducts";
+import styled from "@emotion/styled";
 import { useParams } from "react-router";
 
 const ThemesPage = () => {
@@ -9,10 +10,20 @@ const ThemesPage = () => {
   return (
     <>
       <TheHeader />
-      <ThemesInfo id={id} />
-      <ThemesProducts id={id} />
+      <Main>
+        <ThemesInfo id={id} />
+        <ThemesProducts id={id} />
+      </Main>
     </>
   );
 };
 
 export default ThemesPage;
+
+const Main = styled.main`
+  display: flex;
+  flex-direction: column;
+  background-color: ${({ theme }) => theme.colors.gray.gray00};
+  height: 100%;
+  min-height: 100vh;
+`;

--- a/src/pages/ThemesPage.tsx
+++ b/src/pages/ThemesPage.tsx
@@ -1,0 +1,16 @@
+import ThemesInfo from "@/components/themes/ThemesInfo";
+import ThemesProducts from "@/components/themes/ThemesProducts";
+import { useParams } from "react-router";
+
+const ThemesPage = () => {
+  const { id } = useParams<{ id: string }>();
+
+  return (
+    <div>
+      <ThemesInfo id={id} />
+      <ThemesProducts id={id} />
+    </div>
+  );
+};
+
+export default ThemesPage;

--- a/src/pages/ThemesPage.tsx
+++ b/src/pages/ThemesPage.tsx
@@ -1,3 +1,4 @@
+import TheHeader from "@/components/layout/TheHeader";
 import ThemesInfo from "@/components/themes/ThemesInfo";
 import ThemesProducts from "@/components/themes/ThemesProducts";
 import { useParams } from "react-router";
@@ -6,10 +7,11 @@ const ThemesPage = () => {
   const { id } = useParams<{ id: string }>();
 
   return (
-    <div>
+    <>
+      <TheHeader />
       <ThemesInfo id={id} />
       <ThemesProducts id={id} />
-    </div>
+    </>
   );
 };
 

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -3,5 +3,6 @@ export const ROUTE_PATH = {
   LOGIN: "/login",
   MY_PAGE: "/my",
   ORDER: "/order/:id",
+  THEMES: "/themes/:id",
   NOT_FOUND: "/not-found",
 };

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -5,6 +5,7 @@ import LoginPage from "@/pages/LoginPage";
 import NotFoundPage from "@/pages/NotFoundPage";
 import MyPage from "@/pages/MyPage";
 import OrderPage from "@/pages/OrderPage";
+import ThemesPage from "@/pages/ThemesPage";
 
 const Router = () => {
   return (
@@ -13,6 +14,7 @@ const Router = () => {
       <Route path={ROUTE_PATH.LOGIN} element={<LoginPage />} />
       <Route path={ROUTE_PATH.MY_PAGE} element={<MyPage />} />
       <Route path={ROUTE_PATH.ORDER} element={<OrderPage />} />
+      <Route path={ROUTE_PATH.THEMES} element={<ThemesPage />} />
       <Route path={ROUTE_PATH.NOT_FOUND} element={<NotFoundPage />} />
       <Route
         path="*"

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -3,3 +3,31 @@ export type Theme = {
   name: string;
   image: string;
 };
+
+export type ThemesInfo = {
+  themeId: number;
+  name: string;
+  title: string;
+  description: string;
+  backgroundColor: string;
+};
+
+export type ProductPrice = {
+  basicPrice: number;
+  sellingPrice: number;
+  discountRate: number;
+};
+
+export type BrandInfo = {
+  id: number;
+  name: string;
+  imageURL: string;
+};
+
+export type ThemesProduct = {
+  id: number;
+  name: string;
+  price: ThemesProductPrice;
+  imageURL: string;
+  brandInfo: ThemesBrandInfo;
+};

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -4,7 +4,7 @@ export type Theme = {
   image: string;
 };
 
-export type ThemesInfo = {
+export type ThemeInfo = {
   themeId: number;
   name: string;
   title: string;
@@ -24,10 +24,10 @@ export type BrandInfo = {
   imageURL: string;
 };
 
-export type ThemesProduct = {
+export type ThemeProduct = {
   id: number;
   name: string;
-  price: ThemesProductPrice;
+  price: ProductPrice;
   imageURL: string;
-  brandInfo: ThemesBrandInfo;
+  brandInfo: BrandInfo;
 };


### PR DESCRIPTION
안녕하세요 멘토님 경북대 FE 정인준입니다. 
3단계 테마 상품 목록 페이지 구현하기 진행하였습니다. 

## 구현 사항
- [x] 2단계 피드백 반영
  - [x] api의 요청타입과 응답타입을 모두 타입으로 관리
  - [x] 인증토큰을 인터셉터에서 처리
  - [x] useSessionStorage 키 상수로 관리
  - [x] 인증 에러 공통 레벨에서 처리 -> 커스텀 훅에서 처리
  - [ ] LoginForm useEffect 없이 값을 처리하도록 변경
- [x] 테마 상품 목록 패이지
  - [x] 선물 테마 섹션의 아이템을 클릭하면 테마 상품 목록 페이지로 이동
  - [x] `/api/themes/:themeId/info` api를 통해 선물 테마 섹션의 히어로 영역을 구현
  - [x] 404 에러 발생시 선물하기 홈 페이지로 이동
  - [x] `/api/themes/:themeId/products` api를 통해 상품 리스트 구현
  - [x] 무한 스크롤 기능 구현
  - [x] 상품 리스트가 없으면 빈 페이지를 보여줌

## step2 피드백을 반영하면서
- 인증 에러 공통 레벨에서 처리를 구현하면서 처음에는 인터셉터에서 처리를 하려고 했는데 인터셉터에서는 리액트 훅을 사용할 수 없어 아래의 형태로 작성하였다가 useApiRequest 훅에서 navigate를 사용해서 라우팅하도록 구현하였습니다. 
그렇게 구현하고 나서 주문하기 기능을 보니 커스텀 훅을 사용하지 않고 post 요청을 보내도록 구현해두어 이 경우에 에러 처리가 안되는 것 같다는 생각이 들었습니다. 에러 처리를 어떻게 하는 것이 일반적인지 궁금합니다. 
```
if (error.response?.status === 404) {
      window.location.href = ROUTE_PATH.HOME;
    }
```

- 아래 코드처럼 setData로 상태를 업데이트했더니 비동기 처리 특성 때문에 변화가 바로 반영되지 않는 문제가 있었습니다.
검색해보니 useApiRequest 훅에서 데이터를 반환하는 방식도 있었는데 그렇게 하면 상태로 관리하는 값과 바로 반환하는 데이터가 같지 않은 상황이 생기는 것은 적절하지 않다는 생각이 들어 구현 방법에 고민이 생겨 피드백을 반영하지 못했습니다. 
이런 상황에서 어떤 점을 고려하여 구현하는 것이 좋을까요?
```
LoginForm useEffect 없이 값을 처리하는 부분은 해결하지 못해 일단 구현하지는 못했습니다. 
  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
    e.preventDefault();
    postLoginRequest({
      email: emailInput.value,
      password: passwordInput.value,
    });

    if (userData && !isLoading && !isError && !user?.email) {
      user?.setUserInfo({
        email: userData.email,
        name: userData.name,
        authToken: userData.authToken,
      });

      const redirectPath = new URLSearchParams(location.search).get("redirect");
      navigate(redirectPath || ROUTE_PATH.HOME);
    } else if (isError && !isLoading) {
      toast.error(error);
    }
  };
```