### PR TITLE
경북대 FE 김지훈 - 3단계 테마 상품 목록 페이지 구현하기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { UserProvider } from '@/contexts/UserContext';
 import { ROUTE } from '@/constants/routes';
 import AuthRoute from '@/routes/AuthRoute';
 import PublicRoute from '@/routes/PublicRoute';
+import ThemeProductsPage from '@/pages/ThemeProductsPage';
 
 const App = () => {
   return (
@@ -18,6 +19,8 @@ const App = () => {
           <Route element={<Layout />}>
             {/* 메인페이지 */}
             <Route path={ROUTE.MAIN} element={<MainPage />} />
+
+            <Route path={ROUTE.THEME()} element={<ThemeProductsPage />} />
 
             {/* 로그인 안한 유저만 접근 */}
             <Route

--- a/src/api/product.ts
+++ b/src/api/product.ts
@@ -1,5 +1,5 @@
 import axiosInstance from './axiosInstance';
-import type { Product, ProductSummary } from '@/types/product';
+import type { Product, ProductSummary, ProductList } from '@/types/product';
 
 export const fetchProductRanking = async (
   targetType: string,
@@ -16,5 +16,20 @@ export const fetchProductRanking = async (
 
 export const fetchProductSummary = async (productId: number): Promise<ProductSummary> => {
   const res = await axiosInstance.get(`/products/${productId}/summary`);
+  return res.data.data;
+};
+
+export const fetchThemeProducts = async ({
+  themeId,
+  cursor = 0,
+  limit = 10,
+}: {
+  themeId: number;
+  cursor?: number;
+  limit?: number;
+}): Promise<ProductList> => {
+  const res = await axiosInstance.get(`/themes/${themeId}/products`, {
+    params: { cursor, limit },
+  });
   return res.data.data;
 };

--- a/src/api/theme.ts
+++ b/src/api/theme.ts
@@ -5,3 +5,8 @@ export const fetchThemes = async (): Promise<Theme[]> => {
   const res = await axiosInstance.get('/themes');
   return res.data.data;
 };
+
+export const fetchThemeDetail = async (themeId: number): Promise<Theme> => {
+  const res = await axiosInstance.get(`/themes/${themeId}/info`);
+  return res.data.data;
+};

--- a/src/components/CategorySection.tsx
+++ b/src/components/CategorySection.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from 'react';
 import { fetchThemes } from '@/api/theme';
 import type { Theme } from '@/types/theme';
 import Spinner from '@/components/Spinner';
+import { ROUTE } from '@/constants/routes';
+import { useNavigate } from 'react-router-dom';
 
 const SectionWrapper = styled.section`
   padding: ${({ theme }) => theme.spacing.spacing4};
@@ -52,6 +54,7 @@ const CategorySection = () => {
   const [themes, setThemes] = useState<Theme[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const loadThemes = async () => {
@@ -80,7 +83,7 @@ const CategorySection = () => {
       <Title>선물 테마</Title>
       <Grid>
         {themes.map(({ themeId, name, image }) => (
-          <Item key={themeId}>
+          <Item key={themeId} onClick={() => navigate(ROUTE.THEME(themeId))}>
             <Image src={image} alt={name} />
             <Label>{name}</Label>
           </Item>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -3,5 +3,6 @@ export const ROUTE = {
   LOGIN: '/login',
   MY: '/my',
   ORDER: (productId: string | number = ':productId') => `/order/${productId}`,
+  THEME: (themeId: string | number = ':themeId') => `/theme/${themeId}`,
   NOT_FOUND: '*',
 } as const;

--- a/src/pages/ThemeProductsPage.tsx
+++ b/src/pages/ThemeProductsPage.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import styled from '@emotion/styled';
+import { fetchThemeDetail } from '@/api/theme';
+import type { Theme } from '@/types/theme';
+import { ROUTE } from '@/constants/routes';
+import axios from 'axios';
+import { HttpStatusCode } from 'axios';
+import { toast } from 'react-toastify';
+
+const Hero = styled.section<{ bgColor: string }>`
+  background-color: ${({ bgColor }) => bgColor};
+  padding: ${({ theme }) => theme.spacing.spacing6};
+  color: ${({ theme }) => theme.colors.gray.gray00};
+`;
+
+const Title = styled.h1`
+  ${({ theme }) => theme.typography.title1Bold};
+  margin-top: ${({ theme }) => theme.spacing.spacing2};
+`;
+
+const Description = styled.p`
+  ${({ theme }) => theme.typography.body2Regular};
+`;
+
+const ThemeName = styled.h2`
+  ${({ theme }) => theme.typography.body2Bold};
+`;
+
+const ThemeProductsPage = () => {
+  const { themeId } = useParams<{ themeId: string }>();
+  const navigate = useNavigate();
+  const [theme, setTheme] = useState<Theme | null>(null);
+
+  useEffect(() => {
+    const loadTheme = async () => {
+      try {
+        if (!themeId) {
+          return;
+        }
+        const data = await fetchThemeDetail(Number(themeId));
+        setTheme(data);
+      } catch (error) {
+        if (error instanceof axios.AxiosError) {
+          const status = error.response?.status;
+          const msg = error.response?.data?.data?.message || '테마 정보를 불러오지 못했습니다.';
+
+          if (status === HttpStatusCode.NotFound) {
+            navigate(ROUTE.MAIN);
+          } else {
+            toast.error(msg);
+          }
+        } else {
+          toast.error('오류가 발생했습니다.');
+        }
+      }
+    };
+
+    loadTheme();
+  }, [themeId, navigate]);
+
+  if (!theme) {
+    return null;
+  }
+
+  return (
+    <>
+      <Hero bgColor={theme.backgroundColor}>
+        <ThemeName>{theme.name}</ThemeName>
+        <Title>{theme.title}</Title>
+        <Description>{theme.description}</Description>
+      </Hero>
+    </>
+  );
+};
+
+export default ThemeProductsPage;

--- a/src/pages/ThemeProductsPage.tsx
+++ b/src/pages/ThemeProductsPage.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { fetchThemeDetail } from '@/api/theme';
+import { fetchThemeProducts } from '@/api/product';
 import type { Theme } from '@/types/theme';
+import type { Product } from '@/types/product';
 import { ROUTE } from '@/constants/routes';
-import axios from 'axios';
-import { HttpStatusCode } from 'axios';
+import axios, { HttpStatusCode } from 'axios';
 import { toast } from 'react-toastify';
+import Spinner from '@/components/Spinner';
 
 const Hero = styled.section<{ bgColor: string }>`
   background-color: ${({ bgColor }) => bgColor};
@@ -27,10 +29,66 @@ const ThemeName = styled.h2`
   ${({ theme }) => theme.typography.body2Bold};
 `;
 
+const ProductGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: ${({ theme }) => theme.spacing.spacing5} ${({ theme }) => theme.spacing.spacing3};
+  padding: ${({ theme }) => theme.spacing.spacing4};
+`;
+
+const ProductCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+
+  img {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+    border-radius: ${({ theme }) => theme.spacing.spacing2};
+    margin-bottom: ${({ theme }) => theme.spacing.spacing2};
+  }
+
+  div {
+    ${({ theme }) => theme.typography.body2Regular};
+    color: ${({ theme }) => theme.colors.semantic.textDefault};
+  }
+
+  .brand {
+    ${({ theme }) => theme.typography.label1Regular};
+    color: ${({ theme }) => theme.colors.semantic.textSub};
+    margin-bottom: ${({ theme }) => theme.spacing.spacing1};
+  }
+
+  .name {
+    ${({ theme }) => theme.typography.label1Regular};
+  }
+
+  .price {
+    ${({ theme }) => theme.typography.body1Bold};
+    margin-top: ${({ theme }) => theme.spacing.spacing1};
+  }
+`;
+
+const EmptyMessage = styled.div`
+  padding: ${({ theme }) => theme.spacing.spacing6};
+  text-align: center;
+  color: ${({ theme }) => theme.colors.semantic.textSub};
+`;
+
 const ThemeProductsPage = () => {
   const { themeId } = useParams<{ themeId: string }>();
-  const navigate = useNavigate();
   const [theme, setTheme] = useState<Theme | null>(null);
+  const navigate = useNavigate();
+
+  const [products, setProducts] = useState<Product[]>([]);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const observerRef = useRef<HTMLDivElement | null>(null);
+  const cursorRef = useRef(0);
+  const loadingRef = useRef(false);
+
+  const LIMIT = 20;
 
   useEffect(() => {
     const loadTheme = async () => {
@@ -59,6 +117,69 @@ const ThemeProductsPage = () => {
     loadTheme();
   }, [themeId, navigate]);
 
+  const loadProducts = async () => {
+    if (!themeId || loadingRef.current || !hasMore) {
+      return;
+    }
+
+    loadingRef.current = true;
+    setLoading(true);
+    try {
+      const res = await fetchThemeProducts({
+        themeId: Number(themeId),
+        cursor: cursorRef.current,
+        limit: LIMIT,
+      });
+
+      const seen = new Set(products.map((p) => p.id));
+      const newItems = res.list.filter((item) => !seen.has(item.id));
+
+      setProducts((prev) => [...prev, ...newItems]);
+      cursorRef.current = res.cursor;
+      setHasMore(res.hasMoreList);
+    } catch {
+      toast.error('상품 정보를 불러오지 못했습니다.');
+    } finally {
+      setLoading(false);
+      loadingRef.current = false;
+    }
+  };
+
+  useEffect(() => {
+    if (!themeId) {
+      return;
+    }
+    setProducts([]);
+    cursorRef.current = 0;
+    setHasMore(true);
+    loadingRef.current = false;
+
+    setTimeout(() => {
+      loadProducts();
+    }, 0);
+  }, [themeId]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const first = entries[0];
+        if (first.isIntersecting && hasMore && !loading) {
+          loadProducts();
+        }
+      },
+      {
+        threshold: 0.1,
+      }
+    );
+
+    const current = observerRef.current;
+    if (current) observer.observe(current);
+
+    return () => {
+      if (current) observer.unobserve(current);
+    };
+  }, [hasMore, loading]);
+
   if (!theme) {
     return null;
   }
@@ -70,6 +191,26 @@ const ThemeProductsPage = () => {
         <Title>{theme.title}</Title>
         <Description>{theme.description}</Description>
       </Hero>
+
+      {products.length === 0 && !loading ? (
+        <EmptyMessage>상품이 없습니다.</EmptyMessage>
+      ) : (
+        <>
+          <ProductGrid>
+            {products.map((item) => (
+              <ProductCard key={item.id}>
+                <img src={item.imageURL} alt={item.name} />
+                <div className="brand">{item.brandInfo.name}</div>
+                <div className="name">{item.name}</div>
+                <div className="price">{item.price.sellingPrice.toLocaleString()} 원</div>
+              </ProductCard>
+            ))}
+          </ProductGrid>
+
+          <div ref={observerRef} style={{ height: '1px' }} />
+          {loading && <Spinner />}
+        </>
+      )}
     </>
   );
 };

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -21,3 +21,9 @@ export interface ProductSummary {
   price: number;
   imageURL: string;
 }
+
+export interface ProductList {
+  list: Product[];
+  cursor: number;
+  hasMoreList: boolean;
+}


### PR DESCRIPTION
refactor : instanceof/axios status code 이용 리팩토링
feat : themeId api 데이터 통신을 위한 기능 구현
feat : ROUTE.THEME 상수 추가
feat : ThemeProductsPage연결을 위한 onClick 이벤트 추가
feat : ThemeProductsPage 연결을 위한 라우팅 설정
feat : ThemeProductsPage Hero Section 구현
feat : product api 데이터 통신을 위한 기능 구현
feat : ThemeProductsPage 상품 리스트 구현

안녕하세요 멘토님! 이번 3단계 테마 상품 목록 페이지 구현 미션 코드리뷰 신청합니다.

학습 중에
"페이지를 변경할때마다 API 호출을 하면 리소스를 잡아먹을텐데 이게 최선인가?"라는 궁금증이 생겼습니다.
그래서 꼬리를 무는 질문을 검색 등을 이용해서 찾아보았습니다.
-> 언마운트 후 재마운트되면 useEffect가 다시 실행되서 API 호출이 반복됨. 해결책은?
-> 캐싱 (리액트 쿼리 등으로 캐싱) ex) themeCache라는 map 객체로 로컬에 저장해두고 있으면 API 호출을 생략한다.
-> 그러면 API가 계속 바뀐다면 감지를 어떻게 하는가? 업데이트 버전을 보고 판단하는 건가?
-> 캐싱 무효화 : API 데이터가 바뀌는지 어떻게 감지하고 다시 받아올지 결정하는 방식
	- 시간기반 : 일정 시간이 지나면 무조건 다시 요청
	- 버전기반 : version (updateAt 등)
	- 비교 기반 : 이전 데이터와 새 데이터 객체를 비교해서 변경 여부 판단(비효율적)
바로 다음 미션에서 리액트 쿼리를 사용할 기회가 있다는 것을 알게되어서 다음번 미션에서 적용해보도록 하겠습니다.

혹시나 제가 학습하면서 생긴 궁금증에 대해 피드백 하실 내용이 있다면 말씀해주시면 공부하도록 하겠습니다.
바쁘신 와중에도 시간 내어 코드리뷰해주셔서 감사합니다!