### PR TITLE
경북대 FE 김건호 - 3단계 테마 상품 목록 페이지 구현하기

### DIFF
--- a/src/api/themes/get-theme-info.ts
+++ b/src/api/themes/get-theme-info.ts
@@ -1,0 +1,18 @@
+import { api } from "@/api/api";
+
+export interface ThemeInfoResponseBody {
+  themeId: number;
+  name: string;
+  title: string;
+  description: string;
+  backgroundColor: string;
+}
+
+export const getThemeInfo = async (
+  themeId: number,
+): Promise<ThemeInfoResponseBody> => {
+  const { data: response } = await api.get<BaseResponse<ThemeInfoResponseBody>>(
+    `/themes/${themeId}/info`,
+  );
+  return response.data;
+};

--- a/src/api/themes/get-theme-product.ts
+++ b/src/api/themes/get-theme-product.ts
@@ -1,0 +1,30 @@
+import { api } from "@/api/api";
+import type { ProductType } from "@/types";
+
+export interface ThemeProductRequestBody {
+  themeId: number;
+  cursor?: number;
+  limit?: number;
+}
+
+export interface ThemeProductResponseBody {
+  list: ProductType[];
+  cursor: number;
+  hasMoreList: boolean;
+}
+
+export const getThemeProducts = async ({
+  themeId,
+  limit = 10,
+  cursor = 0,
+}: ThemeProductRequestBody): Promise<ThemeProductResponseBody> => {
+  const { data: response } = await api.get<
+    BaseResponse<ThemeProductResponseBody>
+  >(`/themes/${themeId}/products`, {
+    params: {
+      limit,
+      cursor,
+    },
+  });
+  return response.data;
+};

--- a/src/components/main/PresentTheme.tsx
+++ b/src/components/main/PresentTheme.tsx
@@ -1,5 +1,6 @@
 import { LoadingSpinner } from "@/components/common";
 import { ThemeItem } from "@/components/main";
+import { useRouter } from "@/hooks/common/useRouter";
 import { useGetThemeData } from "@/hooks/themes/useGetThemeData";
 import styled from "@emotion/styled";
 
@@ -40,7 +41,7 @@ const PresentSectionGridContainer = styled.div(({ theme }) => ({
 
 export const PresentTheme = () => {
   const { themes, loading, error, isEmpty } = useGetThemeData();
-
+  const { goThemePage } = useRouter();
   const renderContent = () => {
     if (loading) {
       return <LoadingSpinner />;
@@ -53,7 +54,11 @@ export const PresentTheme = () => {
     return (
       <PresentSectionGridContainer>
         {themes.map(theme => (
-          <ThemeItem key={theme.themeId} {...theme} />
+          <ThemeItem
+            key={theme.themeId}
+            {...theme}
+            onClick={() => goThemePage(theme.themeId)}
+          />
         ))}
       </PresentSectionGridContainer>
     );

--- a/src/components/main/ThemeItem.tsx
+++ b/src/components/main/ThemeItem.tsx
@@ -1,4 +1,3 @@
-import type { CategoryType } from "@/types";
 import styled from "@emotion/styled";
 
 const ThemeItemContainer = styled.div(({ theme }) => ({
@@ -24,10 +23,15 @@ const ThemeItemTitle = styled.p(({ theme }) => ({
   color: `${theme.color.gray[900]}`,
 }));
 
-export const ThemeItem = ({ image, name }: CategoryType) => {
+interface ThemeItemProps {
+  image: string;
+  name: string;
+  onClick: () => void;
+}
+export const ThemeItem = ({ image, name, onClick }: ThemeItemProps) => {
   return (
     <ThemeItemContainer>
-      <ThemeItemImage src={image} alt="테마 이미지" />
+      <ThemeItemImage src={image} alt="테마 이미지" onClick={onClick} />
       <ThemeItemTitle>{name}</ThemeItemTitle>
     </ThemeItemContainer>
   );

--- a/src/components/themes/ThemeProductGrid.tsx
+++ b/src/components/themes/ThemeProductGrid.tsx
@@ -1,0 +1,109 @@
+import { LoadingSpinner } from "@/components/common";
+import { useRouter } from "@/hooks/common/useRouter";
+import { useGetThemeProducts } from "@/hooks/themes/useGetThemeProducts";
+import styled from "@emotion/styled";
+
+const ThemeProductGridContainer = styled.div(({ theme }) => ({
+  display: "grid",
+  gridTemplateColumns: "repeat(3,1fr)",
+  gap: theme.spacing2,
+  padding: theme.spacing4,
+}));
+
+const ThemeProductGridItem = styled.div(({ theme }) => ({
+  backgroundColor: `${theme.color.gray[0]}`,
+  borderRadius: `${theme.spacing3}`,
+  cursor: "pointer",
+  position: "relative",
+}));
+
+const ThemeProductImageContainer = styled.img(({ theme }) => ({
+  width: "100%",
+  aspectRatio: "1 / 1",
+  objectFit: "cover",
+  borderRadius: "4px",
+  marginBottom: `${theme.spacing3}`,
+}));
+
+const ThemeProductCategoryText = styled.p(({ theme }) => ({
+  fontSize: `${theme.typography.label1Regular.fontSize}`,
+  fontWeight: `${theme.typography.label1Regular.fontWeight}`,
+  lineHeight: `${theme.typography.label1Regular.lineHeight}`,
+  color: `${theme.color.gray[500]}`,
+}));
+
+const ThemeProductProductTitle = styled.p(({ theme }) => ({
+  fontSize: `${theme.typography.label1Regular.fontSize}`,
+  fontWeight: `${theme.typography.label1Regular.fontWeight}`,
+  color: `${theme.color.gray[900]}`,
+  marginBottom: `${theme.spacing2}`,
+}));
+
+const ThemeProductPriceText = styled.p(({ theme }) => ({
+  fontSize: `${theme.typography.title2Bold.fontSize}`,
+  fontWeight: `${theme.typography.title2Bold.fontWeight}`,
+  color: `${theme.color.gray[900]}`,
+}));
+
+const LoadingTrigger = styled.div({
+  gridColumn: "1 / -1",
+  display: "flex",
+  justifyContent: "center",
+  padding: "20px",
+});
+
+const EmptyContainer = styled.div(({ theme }) => ({
+  gridColumn: "1 / -1",
+  height: "50vh",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: `${theme.spacing8} 0`,
+  color: `${theme.color.gray[900]}`,
+  fontSize: `${theme.typography.body1Regular.fontSize}`,
+}));
+
+interface ThemeProductGridProps {
+  themeId: number;
+}
+
+export const ThemeProductGrid = ({ themeId }: ThemeProductGridProps) => {
+  const { products, loading, hasMore, ref } = useGetThemeProducts(themeId, 20);
+  const { goOrderPage } = useRouter();
+
+  if (loading && products.length === 0) {
+    return <LoadingSpinner />;
+  }
+  if (!loading && products.length === 0) {
+    return <EmptyContainer>상품이 없습니다.</EmptyContainer>;
+  }
+
+  return (
+    <ThemeProductGridContainer>
+      {products.map((product, index) => (
+        <ThemeProductGridItem
+          key={`${product.id}+${product.name}+${index}`}
+          onClick={() => goOrderPage(product.id)}
+        >
+          <ThemeProductImageContainer
+            src={product.imageURL}
+            alt={product.name}
+          />
+          <ThemeProductCategoryText>
+            {product.brandInfo.name}
+          </ThemeProductCategoryText>
+          <ThemeProductProductTitle>{product.name}</ThemeProductProductTitle>
+          <ThemeProductPriceText>
+            {product.price?.basicPrice}원
+          </ThemeProductPriceText>
+        </ThemeProductGridItem>
+      ))}
+      {loading && products.length > 0 && (
+        <LoadingTrigger>
+          <LoadingSpinner />
+        </LoadingTrigger>
+      )}
+      {hasMore && !loading && <LoadingTrigger ref={ref} />}
+    </ThemeProductGridContainer>
+  );
+};

--- a/src/components/themes/ThemeProductGrid.tsx
+++ b/src/components/themes/ThemeProductGrid.tsx
@@ -68,7 +68,7 @@ interface ThemeProductGridProps {
 }
 
 export const ThemeProductGrid = ({ themeId }: ThemeProductGridProps) => {
-  const { products, loading, hasMore, ref } = useGetThemeProducts(themeId, 20);
+  const { products, loading, hasMore, ref } = useGetThemeProducts(themeId);
   const { goOrderPage } = useRouter();
 
   if (loading && products.length === 0) {
@@ -80,9 +80,9 @@ export const ThemeProductGrid = ({ themeId }: ThemeProductGridProps) => {
 
   return (
     <ThemeProductGridContainer>
-      {products.map((product, index) => (
+      {products.map(product => (
         <ThemeProductGridItem
-          key={`${product.id}+${product.name}+${index}`}
+          key={product.id}
           onClick={() => goOrderPage(product.id)}
         >
           <ThemeProductImageContainer

--- a/src/components/themes/ThemeProductHero.tsx
+++ b/src/components/themes/ThemeProductHero.tsx
@@ -1,0 +1,51 @@
+import { useGetThemeDetail } from "@/hooks/themes/useGetThemeDetail";
+import styled from "@emotion/styled";
+
+const ThemeProductContainer = styled.div<{ backgroundColor?: string }>(
+  ({ theme, backgroundColor }) => ({
+    display: "flex",
+    flexDirection: "column",
+    padding: `${theme.spacing6} ${theme.spacing4} ${theme.spacing5}`,
+    height: "128px",
+    backgroundColor: backgroundColor || theme.color.gray[0],
+  }),
+);
+
+const ThemeProductName = styled.p(({ theme }) => ({
+  fontSize: `${theme.typography.title2Bold.fontSize}`,
+  fontWeight: `${theme.typography.title2Bold.fontWeight}`,
+  lineHeight: `${theme.typography.title2Bold.lineHeight}`,
+  color: `${theme.color.gray[0]}`,
+}));
+
+const ThemeProductTitle = styled.h5(({ theme }) => ({
+  fontSize: `${theme.typography.title1Bold.fontSize}`,
+  fontWeight: `${theme.typography.title1Bold.fontWeight}`,
+  lineHeight: `${theme.typography.title1Bold.lineHeight}`,
+  color: `${theme.color.gray[0]}`,
+}));
+
+const ThemeProductDescription = styled.p(({ theme }) => ({
+  fontSize: `${theme.typography.body1Regular.fontSize}`,
+  fontWeight: `${theme.typography.body1Regular.fontWeight}`,
+  lineHeight: `${theme.typography.body1Regular.lineHeight}`,
+  color: `${theme.color.gray[0]}`,
+}));
+
+interface ThemeProductHeroProps {
+  themeId: number;
+}
+
+export const ThemeProductHero = ({ themeId }: ThemeProductHeroProps) => {
+  const { data: themeInfo } = useGetThemeDetail(themeId);
+
+  return (
+    <ThemeProductContainer backgroundColor={themeInfo?.backgroundColor}>
+      <ThemeProductName>{themeInfo?.name}</ThemeProductName>
+      <ThemeProductTitle>{themeInfo?.title}</ThemeProductTitle>
+      <ThemeProductDescription>
+        {themeInfo?.description}
+      </ThemeProductDescription>
+    </ThemeProductContainer>
+  );
+};

--- a/src/components/themes/ThemeProductLayout.tsx
+++ b/src/components/themes/ThemeProductLayout.tsx
@@ -1,0 +1,19 @@
+import styled from "@emotion/styled";
+import type { ReactNode } from "react";
+
+const ThemeProductLayout = styled.main(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  width: "100%",
+  backgroundColor: `${theme.color.gray[0]}`,
+  minHeight: "100vh",
+  paddingBottom: "50px",
+}));
+
+export const ThemeProductPageLayout = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  return <ThemeProductLayout>{children}</ThemeProductLayout>;
+};

--- a/src/components/themes/index.tsx
+++ b/src/components/themes/index.tsx
@@ -1,0 +1,3 @@
+export { ThemeProductPageLayout } from "@/components/themes/ThemeProductLayout";
+export { ThemeProductHero } from "@/components/themes/ThemeProductHero";
+export { ThemeProductGrid } from "@/components/themes/ThemeProductGrid";

--- a/src/constants/route-path.ts
+++ b/src/constants/route-path.ts
@@ -4,5 +4,6 @@ export const ROUTE_PATH = {
   MY: "/my",
   ORDER: "/order/:id",
   ERROR: "*",
+  THEME: "/themes/:id",
   GO_BACK: -1,
 } as const;

--- a/src/hooks/common/useInview.ts
+++ b/src/hooks/common/useInview.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseInViewProps {
+  callback?: () => void;
+  threshold?: number;
+  rootMargin?: string;
+}
+
+export const useInView = (options: UseInViewProps = {}) => {
+  const { callback, threshold = 0.1, rootMargin = "50px" } = options;
+
+  const [inView, setInView] = useState(false);
+  const elementRef = useRef<HTMLDivElement>(null);
+
+  const handleIntersection = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const entry = entries[0];
+      const isIntersecting = entry.isIntersecting;
+
+      setInView(isIntersecting);
+
+      if (isIntersecting) {
+        callback?.();
+      }
+    },
+    [callback],
+  );
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(handleIntersection, {
+      threshold,
+      rootMargin,
+    });
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [handleIntersection, threshold, rootMargin]);
+
+  return {
+    ref: elementRef,
+    inView,
+  };
+};

--- a/src/hooks/common/useRouter.tsx
+++ b/src/hooks/common/useRouter.tsx
@@ -20,7 +20,12 @@ export const useRouter = () => {
     },
     [navigate],
   );
-
+  const goThemePage = useCallback(
+    (id: number) => {
+      navigate(ROUTE_PATH.THEME.replace(":id", id.toString()));
+    },
+    [navigate],
+  );
   const goLoginPage = useCallback(
     ({ redirect }: { redirect?: boolean }) => {
       if (redirect) {
@@ -42,6 +47,7 @@ export const useRouter = () => {
     goHomePage,
     goBack,
     goOrderPage,
+    goThemePage,
     goLoginPage,
     goMyPage,
   };

--- a/src/hooks/themes/useGetThemeDetail.ts
+++ b/src/hooks/themes/useGetThemeDetail.ts
@@ -1,0 +1,35 @@
+import { ApiError } from "@/api/custom-error";
+import {
+  getThemeInfo,
+  type ThemeInfoResponseBody,
+} from "@/api/themes/get-theme-info";
+import { useApiStatus } from "@/hooks/common/useApiStatus";
+import { useRouter } from "@/hooks/common/useRouter";
+import { useEffect } from "react";
+
+export const useGetThemeDetail = (themeId: number) => {
+  const { data, error, execute, loading } =
+    useApiStatus<ThemeInfoResponseBody>();
+  const { goHomePage } = useRouter();
+
+  useEffect(() => {
+    if (!themeId || isNaN(themeId)) {
+      goHomePage();
+      return;
+    }
+    execute(() => getThemeInfo(themeId)).catch(error => {
+      if (error instanceof ApiError && error.name === "ApiError") {
+        const apiError = error;
+        if (apiError.statusCode === 404) {
+          goHomePage();
+        }
+      }
+    });
+  }, [execute, themeId]);
+
+  return {
+    data,
+    error,
+    loading,
+  };
+};

--- a/src/hooks/themes/useGetThemeProducts.ts
+++ b/src/hooks/themes/useGetThemeProducts.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState, type RefObject } from "react";
+import {
+  getThemeProducts,
+  type ThemeProductResponseBody,
+} from "@/api/themes/get-theme-product";
+import { useApiStatus } from "@/hooks/common/useApiStatus";
+import { useInView } from "@/hooks/common/useInview";
+import type { ProductType } from "@/types";
+
+interface UseThemeProductsResult {
+  products: ProductType[];
+  loading: boolean;
+  error: Error | null;
+  hasMore: boolean;
+  inView: boolean;
+  ref: RefObject<HTMLDivElement | null>;
+  fetchNextPage: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export const useGetThemeProducts = (
+  themeId: number,
+  limit: number = 10,
+  inViewOptions?: { threshold?: number; rootMargin?: string },
+): UseThemeProductsResult => {
+  const [products, setProducts] = useState<ProductType[]>([]);
+  const [cursor, setCursor] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+
+  const { data, loading, error, execute } =
+    useApiStatus<ThemeProductResponseBody>();
+
+  const fetchProducts = useCallback(
+    async (currentCursor: number, isRefresh: boolean = false) => {
+      return execute(() =>
+        getThemeProducts({
+          themeId,
+          cursor: currentCursor,
+          limit,
+        }),
+      ).then(() => {
+        if (data) {
+          setProducts(prev =>
+            isRefresh ? data.list : [...prev, ...data.list],
+          );
+          setCursor(data.cursor);
+          setHasMore(data.hasMoreList);
+        }
+      });
+    },
+    [execute, themeId, limit, data],
+  );
+
+  const fetchNextPage = useCallback(async () => {
+    if (!loading && hasMore) {
+      await fetchProducts(cursor);
+    }
+  }, [fetchProducts, cursor, loading, hasMore]);
+
+  const refresh = useCallback(async () => {
+    setProducts([]);
+    setCursor(0);
+    setHasMore(true);
+    await fetchProducts(0, true);
+  }, [fetchProducts]);
+
+  const { ref, inView } = useInView({
+    callback: fetchNextPage,
+    ...inViewOptions,
+  });
+
+  useEffect(() => {
+    fetchProducts(0, true);
+  }, [themeId]);
+
+  useEffect(() => {
+    if (data) {
+      setProducts(prev => (cursor === 0 ? data.list : [...prev, ...data.list]));
+      setCursor(data.cursor);
+      setHasMore(data.hasMoreList);
+    }
+  }, [data]);
+
+  return {
+    products,
+    loading,
+    error,
+    hasMore,
+    inView,
+    ref,
+    fetchNextPage,
+    refresh,
+  };
+};

--- a/src/hooks/themes/useGetThemeProducts.ts
+++ b/src/hooks/themes/useGetThemeProducts.ts
@@ -27,28 +27,31 @@ export const useGetThemeProducts = (
   const [cursor, setCursor] = useState(0);
   const [hasMore, setHasMore] = useState(true);
 
-  const { data, loading, error, execute } =
-    useApiStatus<ThemeProductResponseBody>();
+  const { loading, error, execute } = useApiStatus<ThemeProductResponseBody>();
 
   const fetchProducts = useCallback(
     async (currentCursor: number, isRefresh: boolean = false) => {
-      return execute(() =>
-        getThemeProducts({
-          themeId,
-          cursor: currentCursor,
-          limit,
-        }),
-      ).then(() => {
-        if (data) {
+      try {
+        await execute(async () => {
+          const response = await getThemeProducts({
+            themeId,
+            cursor: currentCursor,
+            limit,
+          });
+
           setProducts(prev =>
-            isRefresh ? data.list : [...prev, ...data.list],
+            isRefresh ? response.list : [...prev, ...response.list],
           );
-          setCursor(data.cursor);
-          setHasMore(data.hasMoreList);
-        }
-      });
+          setCursor(response.cursor);
+          setHasMore(response.hasMoreList);
+
+          return response;
+        });
+      } catch (error) {
+        console.error("Failed to fetch products:", error);
+      }
     },
-    [execute, themeId, limit, data],
+    [execute, themeId, limit],
   );
 
   const fetchNextPage = useCallback(async () => {
@@ -72,14 +75,6 @@ export const useGetThemeProducts = (
   useEffect(() => {
     fetchProducts(0, true);
   }, [themeId]);
-
-  useEffect(() => {
-    if (data) {
-      setProducts(prev => (cursor === 0 ? data.list : [...prev, ...data.list]));
-      setCursor(data.cursor);
-      setHasMore(data.hasMoreList);
-    }
-  }, [data]);
 
   return {
     products,

--- a/src/pages/ThemeProductPage.tsx
+++ b/src/pages/ThemeProductPage.tsx
@@ -1,0 +1,16 @@
+import {
+  ThemeProductGrid,
+  ThemeProductHero,
+  ThemeProductPageLayout,
+} from "@/components/themes";
+import { useParams } from "react-router-dom";
+
+export const ThemeProductPage = () => {
+  const { id: themeId } = useParams<{ id: string }>();
+  return (
+    <ThemeProductPageLayout>
+      <ThemeProductHero themeId={Number(themeId)} />
+      <ThemeProductGrid themeId={Number(themeId)} />
+    </ThemeProductPageLayout>
+  );
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,3 +3,4 @@ export { MainPage } from "@/pages/MainPage";
 export { NotFoundPage } from "@/pages/NotFoundPage";
 export { MyPage } from "@/pages/MyPage";
 export { OrderPage } from "@/pages/OrderPage";
+export { ThemeProductPage } from "@/pages/ThemeProductPage";

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,7 +1,14 @@
 import { PrivateRoute, PublicRoute } from "@/components/auth";
 import { Header } from "@/components/main";
 import { ROUTE_PATH } from "@/constants";
-import { LoginPage, MainPage, MyPage, NotFoundPage, OrderPage } from "@/pages";
+import {
+  LoginPage,
+  MainPage,
+  MyPage,
+  NotFoundPage,
+  OrderPage,
+  ThemeProductPage,
+} from "@/pages";
 import { BrowserRouter, Outlet, Route, Routes } from "react-router-dom";
 
 const Layout = () => {
@@ -19,6 +26,7 @@ const Router = () => {
       <Routes>
         <Route element={<Layout />}>
           <Route path={ROUTE_PATH.HOME} element={<MainPage />} />
+          <Route path={ROUTE_PATH.THEME} element={<ThemeProductPage />} />
           <Route element={<PublicRoute />}>
             <Route path={ROUTE_PATH.LOGIN} element={<LoginPage />} />
           </Route>


### PR DESCRIPTION
안녕하세요 멘토님!
3단계 과제인 테마 상품 목록 페이지 구현하기를 진행했습니다!

---

## 구현내용
- `intersectionObserverAPI`를 사용하여 `useInView`를 구현했습니다.
- `useInView`와 `useApiStatus`를 조합하여 `useGetThemeProducts`를 구현했습니다.
- 테마 상품 목록 페이지를 구현했습니다.
  - 히어로 섹션을 구현했습니다.
    - 요구사항대로 404에러 발생 시, home으로 이동하도록 했습니다.
  - 테마 상품 목록 섹션을 구현했습니다.
    - 요구사행대로 무한 스크롤 기반의 데이터 페칭을 사용했습니다.
    - 상품이 없으면 빈 페이지와 함께 상품이 없다는 텍스트를 노출시켰습니다.

---

## 궁금한 내용
단순한 컴포넌트의 경우 공통으로 분리해도 사용함에 문제가 없는데, 특정 컴포넌트를 분리하게 되면 사용하는 위치에 따라 옵션이나 로직이 추가되면서 좀 복잡해지게 되는 경우가 있었습니다.
어쩔때는 컴포넌트를 분리해서 Composition방식으로 새 컴포넌트를 만들던가, 아니면 중복된 코드를 조금 허용하는 방식으로 뒀습니다.
- 이럴 때 멘토님이 공통으로 분리하는 기준, 공통으로 분리했지만 시간이 지나 복잡해졌을 때 어떻게 대처하시는지 궁금합니다!